### PR TITLE
Fix sorting of versions for search results

### DIFF
--- a/source/wiz/command_line.py
+++ b/source/wiz/command_line.py
@@ -7,6 +7,7 @@ import datetime
 import os
 import time
 import textwrap
+import re
 
 import click
 import six
@@ -1425,6 +1426,79 @@ def display_definition(definition):
     _display(definition.ordered_data())
 
 
+def _compare_semver(left, right):
+    """
+    Compares two semantic versions as per https://semver.org/ with a small
+    adjustment. The regex allows for missing patch versions as well as custom
+    pre-release tags. Intended to be used with Python's `sorted` function.
+
+    :param left: First semantic version to compare
+    :type left: String
+    :param right: Second semantic version to compare
+    :type right: String
+
+    :return: Returns 0 if versions are equal, -1 if left < right,
+             or 1 if left > right
+    """
+    parse_semver = re.compile(
+        (
+            r"^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)(\.(?P<patch>0|[1-9]\d*)"
+            r"(?:-?(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\."
+            r"(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?"
+            r"(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)?$"
+        )
+    )
+    left_match = parse_semver.search(left)
+    right_match = parse_semver.search(right)
+
+    if left_match.group("major") != right_match.group("major"):
+        return int(left_match.group("major")) - int(right_match.group("major"))
+    if left_match.group("minor") != right_match.group("minor"):
+        return int(left_match.group("minor")) - int(right_match.group("minor"))
+
+    # If patch missing, assume 0
+    left_patch = int(left_match.group("patch")) if left_match.group("patch") else 0
+    right_patch = int(right_match.group("patch")) if right_match.group("patch") else 0
+    if left_patch != right_patch:
+        return left_patch - right_patch
+
+    # Non pre-release is in front of a pre-release
+    if left_match.group("prerelease") and not right_match.group("prerelease"):
+        return -1
+
+    if not left_match.group("prerelease") and right_match.group("prerelease"):
+        return 1
+
+    if left_match.group("prerelease") and right_match.group("prerelease"):
+        prerelease_match = re.compile((r"^(?P<first>[a-zA-Z]+)"
+                                       r"\.?(?P<second>[a-z0-9]+)"))
+        left_prerelease = prerelease_match.search(left_match.group("prerelease"))
+        right_prerelease = prerelease_match.search(right_match.group("prerelease"))
+
+        # If names match, compare second part, else just compare names
+        if left_prerelease.group("first") == right_prerelease.group("first"):
+            if left_prerelease.group("second") and right_prerelease.group("second"):
+                # Handle case of "alpha.beta" or "alpha.11"
+                try:
+                    return (int(left_prerelease.group("second")) -
+                            int(right_prerelease.group("second")))
+                except ValueError:
+                    if (left_prerelease.group("second") <
+                        right_prerelease.group("second")):
+                        return -1
+                    elif (left_prerelease.group("second") >
+                          right_prerelease.group("second")):
+                        return 1
+        else:
+            if left_prerelease.group("first") < right_prerelease.group("first"):
+                return -1
+            elif left_prerelease.group("first") > right_prerelease.group("first"):
+                return 1
+
+    return 0
+
+
+
 def display_command_mapping(
     command_mapping, package_mapping, registries, all_versions=False,
     with_system=False
@@ -1488,7 +1562,9 @@ def display_command_mapping(
     success = False
 
     for command, identifier in sorted(command_mapping.items()):
-        versions = sorted(package_mapping[identifier].keys(), reverse=True)
+        versions = sorted(package_mapping[identifier].keys(),
+                          cmp=_compare_semver,
+                          reverse=True)
 
         # Filter latest version if requested.
         if not all_versions:
@@ -1585,7 +1661,9 @@ def display_package_mapping(
     success = False
 
     for identifier in sorted(package_mapping.keys()):
-        versions = sorted(package_mapping[identifier].keys(), reverse=True)
+        versions = sorted(package_mapping[identifier].keys(),
+                          cmp=_compare_semver,
+                          reverse=True)
 
         # Filter latest version if requested.
         if not all_versions:

--- a/test/unit/test_command_line.py
+++ b/test/unit/test_command_line.py
@@ -3514,3 +3514,38 @@ def test_edit_error_raised(
     mocked_history_record_action.assert_called_once_with(
         "RAISE_EXCEPTION", error=exception
     )
+
+def test_semver_sort_major_minor_path():
+    versions = ['5.3.1', '5.10.0', '5.9.5', '5.1.1', '5.9.4', '5.9.1', '5.9.0',
+                '5.8.2', '5.3.2', '5.2.0', '5.1.0', '5.3.0']
+    expected = ['5.10.0', '5.9.5', '5.9.4', '5.9.1', '5.9.0', '5.8.2',
+                '5.3.2', '5.3.1', '5.3.0','5.2.0', '5.1.1', '5.1.0', ]
+
+
+    compare = wiz.command_line._compare_semver
+    out = sorted(versions, cmp=compare, reverse=True)
+    assert out == expected
+
+def test_semver_sort_no_patch():
+    versions = ['5.3', '5.10', '5.9.0', '5.1', '5.3.2']
+    expected = ['5.10', '5.9.0', '5.3.2', '5.3', '5.1' ]
+
+
+    compare = wiz.command_line._compare_semver
+    out = sorted(versions, cmp=compare, reverse=True)
+    assert out == expected
+
+def test_semver_with_prereleases():
+
+    versions = ['4.21.4', '4.21.3', '4.21.2', "1.0.0-alpha", '4.21.1', '4.21.0',
+                '4.1.0', '4.0.0', '4.21.2b0', '3.13.1', '3.13.0', '3.12.0',
+                "1.0.0-beta", "1.0.0-alpha.1", "1.0.0-alpha.beta","1.0.0",
+                "1.0.0-beta.2","1.0.0-beta.11",'4.0.0b0', "1.0.0-rc.1"]
+
+    expected = ['4.21.4', '4.21.3', '4.21.2', '4.21.2b0', '4.21.1', '4.21.0',
+                '4.1.0', '4.0.0', '4.0.0b0', '3.13.1', '3.13.0', '3.12.0',
+                "1.0.0", "1.0.0-rc.1", "1.0.0-beta.11","1.0.0-beta.2",
+                "1.0.0-beta","1.0.0-alpha.beta","1.0.0-alpha.1",  "1.0.0-alpha"]
+    compare = wiz.command_line._compare_semver
+    out = sorted(versions, cmp=compare, reverse=True)
+    assert out == expected


### PR DESCRIPTION
Uses a custom compare function to sort the versions into the correct order. This however highlights an issue with the versioning as they don't always follow official semantic version [conventions](https://semver.org/)[1] 

Therefore the regular expression was modified to handle edge cases that cropped up in preliminary testing. Unfortunately I don't know what possible version formats there can be out there, so this handles what I've seen so far, which includes:

* missing patch field
* custom pre-release format like 0b0 or 0a1

There could be any number of version formats used out there, so it might be worth verifying versions with something like the [Python semver package](https://pypi.org/project/semver/)[2] to ensure that the compare function doesn't get even longer to handle all the possible formats and restrict versioning to formats that follow the semantic version spec.

If the priority is to allow for any version format, then unfortunately sorting them will become rather complicated.

FIX #7