### PR TITLE
Resolver refactoring

### DIFF
--- a/doc/release/migration_notes.rst
+++ b/doc/release/migration_notes.rst
@@ -7,6 +7,35 @@ Migration notes
 This section will show more detailed information when relevant for switching to
 a new version, such as when upgrading involves backwards incompatibilities.
 
+.. _release/migration/3.3.0:
+
+Migrate to 3.3.0
+================
+
+.. rubric:: Exceptions
+
+The following exceptions have been renamed for consistency:
+
+* :exc:`wiz.exception.InvalidVersion` → :exc:`wiz.exception.VersionError`
+* :exc:`wiz.exception.InvalidRequirement` →
+  :exc:`wiz.exception.RequirementError`
+* :exc:`wiz.exception.IncorrectSystem` → :exc:`wiz.exception.CurrentSystemError`
+* :exc:`wiz.exception.IncorrectDefinition` →
+  :exc:`wiz.exception.DefinitionError`
+
+.. rubric:: API
+
+The following functions have been removed as part of the refactoring process of
+:mod:`wiz.graph`:
+
+* :func:`wiz.graph.generate_variant_combinations`
+* :func:`wiz.graph.trim_unreachable_from_graph`
+* :func:`wiz.graph.updated_by_distance`
+* :func:`wiz.graph.validate`
+* :func:`wiz.graph.extract_ordered_packages`
+* :func:`wiz.graph.relink_parents`
+* :func:`wiz.graph.sanitize_requirement`
+
 .. _release/migration/3.1.0:
 
 Migrate to 3.1.0

--- a/doc/release/release_notes.rst
+++ b/doc/release/release_notes.rst
@@ -178,7 +178,7 @@ Release Notes
     .. change:: fixed
 
         Updated `monkey patching <https://en.wikipedia.org/wiki/Monkey_patch>`_
-        of :class:`packaging.requirements.Requirement` to allow multiple
+        of :class:`packaging.requirements.Requirement` to allow for multiple
         :ref:`namespaces <definition/namespace>` separated by two colons
         (e.g. ``name1::name2::foo``).
 

--- a/doc/release/release_notes.rst
+++ b/doc/release/release_notes.rst
@@ -4,6 +4,190 @@
 Release Notes
 *************
 
+.. release:: Upcoming
+
+    .. change:: new
+
+        Added following command to limit the maximum number of attempts to
+        resolve a context before raising an error:
+
+        * :option:`wiz use -ma/--max-attempts <wiz use -ma>`
+        * :option:`wiz run -ma/--max-attempts <wiz run -ma>`
+
+    .. change:: new
+
+        Added following command to limit the maximum number of combinations
+        which can be generated from conflicting variants during the context
+        resolution process:
+
+        * :option:`wiz use -mc/--max-combinations <wiz use -mc>`
+        * :option:`wiz run -mc/--max-combinations <wiz run -mc>`
+
+    .. change:: changed
+
+        Updated :func:`wiz.resolve_context` to add keyword arguments which
+        provide a maximum number of attempts to resolve a context before raising
+        an error, and a maximum number of combinations which can be generated
+        from conflicting variants during the context resolution process.
+
+    .. change:: changed
+
+        Updated :class:`wiz.graph.Resolver` constructor to add keyword arguments
+        which provide a maximum number of resolution attempts before raising
+        an error, and a maximum number of combinations which can be generated
+        from conflicting variants.
+
+    .. change:: changed
+
+        Refactored :mod:`wiz.graph` to provide a better `separation of concerns
+        <https://en.wikipedia.org/wiki/Separation_of_concerns>`_ between stages
+        of the resolution process.
+
+        The :class:`~wiz.graph.Resolver` class handles the creation of the
+        initial :class:`~wiz.graph.Graph` and the extraction and management of
+        :class:`~wiz.graph.Combination` instances. The newly added
+        :class:`~wiz.graph.Combination` class handles the version conflict
+        resolution, the graph validation and the packages extraction.
+
+    .. change:: changed
+
+        Removed :func:`wiz.graph.generate_variant_combinations` and added logic
+        to :meth:`wiz.graph.Resolver.extract_combinations` to improve code
+        readability.
+
+    .. change:: changed
+
+        Removed :func:`wiz.graph.trim_unreachable_from_graph` and
+        :func:`wiz.graph.trim_invalid_from_graph` and added logic to
+        :meth:`wiz.graph.Combination.prune_graph` to improve code readability.
+
+    .. change:: changed
+
+        Removed :func:`wiz.graph.updated_by_distance` and
+        :func:`wiz.graph.extract_conflicting_nodes` and added logic to
+        :meth:`wiz.graph.Combination.resolve_conflicts` to improve code
+        readability.
+
+    .. change:: changed
+
+        Removed :func:`wiz.graph.validate` and added logic to
+        :meth:`wiz.graph.Combination.validate` to improve code readability.
+
+    .. change:: changed
+
+        Removed :func:`wiz.graph.extract_ordered_packages` and added logic to
+        :meth:`wiz.graph.Combination.extract_packages` to improve code
+        readability.
+
+    .. change:: changed
+
+        Removed :func:`wiz.graph.extract_ordered_packages` and added logic to
+        :meth:`wiz.graph.Combination.extract_packages` to improve code
+        readability.
+
+    .. change:: changed
+
+        Removed :func:`wiz.graph.relink_parents` and added logic to
+        :meth:`wiz.graph.Graph.relink_parents`. This change was necessary to
+        record potential relinking error within the graph instead of raising
+        an exception immediately as the node bearing the error might be removed
+        during the conflict resolution process.
+
+    .. change:: new
+
+        Added :func:`wiz.graph.generate_variant_permutations` to yield all
+        possible permutations between variant groups in an optimized order.
+        It now checks the requirement compatibility between each variant node to
+        prevent wasting time in combination that can not be resolved, hence
+        providing a major performance boost for definition containing a lot of
+        :ref:`variants <definition/variants>`.
+
+    .. change:: new
+
+        Added :func:`wiz.graph.compute_conflicting_matrix` to compute
+        compatibility between each variant node.
+
+    .. change:: changed
+
+        Moved :func:`wiz.graph.sanitize_requirement` to
+        :func:`wiz.utility.sanitize_requirement` and improved logic to prevent
+        confusion when the package does not contain a :ref:`namespace
+        <definition/namespace>`.
+
+    .. change:: new
+
+        Added :func:`wiz.utility.match` to check whether a
+        :class:`~packaging.requirements.Requirement` instance is compatible
+        with a :class:`wiz.package.Package` instance. This logic was previously
+        included in :meth:`wiz.graph.Graph.find`.
+
+    .. change:: new
+
+        Added :func:`wiz.utility.extract_namespace` to retrieve a
+        :ref:`namespace <definition/namespace>` from a
+        :class:`~packaging.requirements.Requirement` instance. This logic was
+        previously included in :meth:`wiz.graph.Graph.find`.
+
+    .. change:: new
+
+        Added :func:`wiz.utility.check_conflicting_requirements` to check
+        whether two :class:`wiz.package.Package` instances contain conflicting
+        requirements.
+
+    .. change:: fixed
+
+        Updated :class:`wiz.graph.Resolver` to prevent discarding graph
+        combinations containing a node which has been flagged as conflict or
+        error in a previous iteration. This logic was flawed as these nodes
+        could be removed during the conflict resolution process, leading to a
+        false negative evaluation of a graph combination.
+
+    .. change:: fixed
+
+        Updated :meth:`wiz.graph.Combination.resolve_conflicts` to better
+        handle resolution of circular conflicts.
+
+    .. change:: fixed
+
+        Updated :meth:`wiz.graph.Resolver.discover_combinations` to prune
+        unreachable nodes from the graph after downgrading node versions.
+        Previously, variant conflicts could be detected from nodes which had
+        been removed from the graph.
+
+    .. change:: changed
+
+        Updated following exception names for consistency:
+
+        * :exc:`wiz.exception.InvalidVersion` →
+          :exc:`wiz.exception.VersionError`
+        * :exc:`wiz.exception.InvalidRequirement` →
+          :exc:`wiz.exception.RequirementError`
+        * :exc:`wiz.exception.IncorrectSystem` →
+          :exc:`wiz.exception.CurrentSystemError`
+        * :exc:`wiz.exception.IncorrectSystem` →
+          :exc:`wiz.exception.CurrentSystemError`
+
+    .. change:: new
+
+        Added new exceptions inheriting from
+        :exc:`wiz.exception.GraphResolutionError` to better handle flow of data:
+
+        * :exc:`wiz.exception.GraphConflictsError`
+        * :exc:`wiz.exception.GraphInvalidNodesError`
+        * :exc:`wiz.exception.GraphVariantsError`
+
+    .. change:: changed
+
+        Updated :class:`wiz.package.Package` constructor to raise an error if
+        the variant index is missing or incorrect.
+
+    .. change:: fixed
+
+        Updated `monkey patching <https://en.wikipedia.org/wiki/Monkey_patch>`_
+        of :class:`packaging.requirements.Requirement` to allow multiple
+        :ref:`namespaces <definition/namespace>` separated by two colons
+        (e.g. ``name1::name2::foo``).
+
 .. release:: 3.2.5
     :date: 2020-09-15
 

--- a/doc/release/release_notes.rst
+++ b/doc/release/release_notes.rst
@@ -8,7 +8,7 @@ Release Notes
 
     .. change:: new
 
-        Added following command to limit the maximum number of attempts to
+        Added the following commands to limit the maximum number of attempts to
         resolve a context before raising an error:
 
         * :option:`wiz use -ma/--max-attempts <wiz use -ma>`
@@ -16,7 +16,7 @@ Release Notes
 
     .. change:: new
 
-        Added following command to limit the maximum number of combinations
+        Added the following commands to limit the maximum number of combinations
         which can be generated from conflicting variants during the context
         resolution process:
 
@@ -51,33 +51,40 @@ Release Notes
 
     .. change:: changed
 
-        Removed :func:`wiz.graph.generate_variant_combinations` and added logic
-        to :meth:`wiz.graph.Resolver.extract_combinations` to improve code
-        readability.
+        Removed the following functions to improve code readability and move
+        logic into different callbacks:
 
-    .. change:: changed
+        +----------------+----------------------------------------------------+
+        | Removed        | * :func:`wiz.graph.generate_variant_combinations`  |
+        +----------------+----------------------------------------------------+
+        | Logic moved to | * :meth:`wiz.graph.Resolver.extract_combinations`  |
+        +----------------+----------------------------------------------------+
 
-        Removed :func:`wiz.graph.trim_unreachable_from_graph` and
-        :func:`wiz.graph.trim_invalid_from_graph` and added logic to
-        :meth:`wiz.graph.Combination.prune_graph` to improve code readability.
+        +----------------+----------------------------------------------------+
+        | Removed        | * :func:`wiz.graph.trim_unreachable_from_graph`    |
+        |                | * :func:`wiz.graph.trim_invalid_from_graph`        |
+        +----------------+----------------------------------------------------+
+        | Logic moved to | * :meth:`wiz.graph.Combination.prune_graph`        |
+        +----------------+----------------------------------------------------+
 
-    .. change:: changed
+        +----------------+----------------------------------------------------+
+        | Removed        | * :func:`wiz.graph.updated_by_distance`            |
+        |                | * :func:`wiz.graph.extract_conflicting_nodes`      |
+        +----------------+----------------------------------------------------+
+        | Logic moved to | * :meth:`wiz.graph.Combination.resolve_conflicts`  |
+        +----------------+----------------------------------------------------+
 
-        Removed :func:`wiz.graph.updated_by_distance` and
-        :func:`wiz.graph.extract_conflicting_nodes` and added logic to
-        :meth:`wiz.graph.Combination.resolve_conflicts` to improve code
-        readability.
+        +----------------+----------------------------------------------------+
+        | Removed        | * :func:`wiz.graph.validate`                       |
+        +----------------+----------------------------------------------------+
+        | Logic moved to | * :meth:`wiz.graph.Combination.validate`           |
+        +----------------+----------------------------------------------------+
 
-    .. change:: changed
-
-        Removed :func:`wiz.graph.validate` and added logic to
-        :meth:`wiz.graph.Combination.validate` to improve code readability.
-
-    .. change:: changed
-
-        Removed :func:`wiz.graph.extract_ordered_packages` and added logic to
-        :meth:`wiz.graph.Combination.extract_packages` to improve code
-        readability.
+        +----------------+----------------------------------------------------+
+        | Removed        | * :func:`wiz.graph.extract_ordered_packages`       |
+        +----------------+----------------------------------------------------+
+        | Logic moved to | * :meth:`wiz.graph.Combination.extract_packages`   |
+        +----------------+----------------------------------------------------+
 
     .. change:: changed
 
@@ -92,7 +99,7 @@ Release Notes
         Added :func:`wiz.graph.generate_variant_permutations` to yield all
         possible permutations between variant groups in an optimized order.
         It now checks the requirement compatibility between each variant node to
-        prevent wasting time in combination that can not be resolved, hence
+        prevent wasting time in combinations that can not be resolved, hence
         providing a major performance boost for definition containing a lot of
         :ref:`variants <definition/variants>`.
 

--- a/doc/release/release_notes.rst
+++ b/doc/release/release_notes.rst
@@ -81,12 +81,6 @@ Release Notes
 
     .. change:: changed
 
-        Removed :func:`wiz.graph.extract_ordered_packages` and added logic to
-        :meth:`wiz.graph.Combination.extract_packages` to improve code
-        readability.
-
-    .. change:: changed
-
         Removed :func:`wiz.graph.relink_parents` and added logic to
         :meth:`wiz.graph.Graph.relink_parents`. This change was necessary to
         record potential relinking error within the graph instead of raising
@@ -164,8 +158,8 @@ Release Notes
           :exc:`wiz.exception.RequirementError`
         * :exc:`wiz.exception.IncorrectSystem` →
           :exc:`wiz.exception.CurrentSystemError`
-        * :exc:`wiz.exception.IncorrectSystem` →
-          :exc:`wiz.exception.CurrentSystemError`
+        * :exc:`wiz.exception.IncorrectDefinition` →
+          :exc:`wiz.exception.DefinitionError`
 
     .. change:: new
 

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ TEST_REQUIRES = [
     "pytest >= 4, < 5",
     "pytest-benchmark >= 3.2.3, < 4",
     "pytest-cov >= 2, < 3",
-    "pytest-mock >= 0.11, < 1",
+    "pytest-mock >= 2, < 3",
     "pytest-runner >= 2.7, < 3",
     "pytest-xdist >= 1.18, < 2"
 ]

--- a/source/wiz/__init__.py
+++ b/source/wiz/__init__.py
@@ -210,11 +210,11 @@ def resolve_context(
     :param maximum_combinations: Maximum number of combinations which can be
         generated from conflicting variants. Default is None, which means
         that the default value will be picked from the :ref:`configuration
-        <configuration`.
+        <configuration>`.
 
     :param maximum_attempts: Maximum number of resolution attempts before
         raising an error. Default is None, which means  that the default
-        value will be picked from the :ref:`configuration <configuration`.
+        value will be picked from the :ref:`configuration <configuration>`.
 
     :return: Context mapping.
 

--- a/source/wiz/__init__.py
+++ b/source/wiz/__init__.py
@@ -162,7 +162,7 @@ def fetch_package_request_from_command(command_request, definition_mapping):
 
 def resolve_context(
     requests, definition_mapping=None, ignore_implicit=False,
-    environ_mapping=None
+    environ_mapping=None, maximum_combinations=None, maximum_attempts=None
 ):
     """Return context mapping from *requests*.
 
@@ -207,6 +207,15 @@ def resolve_context(
     :param environ_mapping: Mapping of environment variables which would be
         augmented by the resolved environment. Default is None.
 
+    :param maximum_combinations: Maximum number of combinations which can be
+        generated from conflicting variants. Default is None, which means
+        that the default value will be picked from the :ref:`configuration
+        <configuration`.
+
+    :param maximum_attempts: Maximum number of resolution attempts before
+        raising an error. Default is None, which means  that the default
+        value will be picked from the :ref:`configuration <configuration`.
+
     :return: Context mapping.
 
     :raise: :exc:`wiz.exception.GraphResolutionError` if the resolution graph
@@ -231,7 +240,9 @@ def resolve_context(
 
     registries = definition_mapping["registries"]
     resolver = wiz.graph.Resolver(
-        definition_mapping[wiz.symbol.PACKAGE_REQUEST_TYPE]
+        definition_mapping[wiz.symbol.PACKAGE_REQUEST_TYPE],
+        maximum_combinations=maximum_combinations,
+        maximum_attempts=maximum_attempts,
     )
     packages = resolver.compute_packages(requirements)
 

--- a/source/wiz/__init__.py
+++ b/source/wiz/__init__.py
@@ -125,13 +125,11 @@ def fetch_package_request_from_command(command_request, definition_mapping):
 
     Example::
 
-        >>> definition_mapping = {
+        >>> mapping = {
         ...     "command": {"hiero": "nuke"},
         ...     "package": {"nuke": ...}
         ... }
-        >>> fetch_package_request_from_command(
-        ...     "hiero==10.5.*", definition_mapping
-        ... )
+        >>> fetch_package_request_from_command("hiero==10.5.*", mapping)
         nuke==10.5.*
 
     :param command_request: String indicating which command should be fetched.

--- a/source/wiz/_requirement.py
+++ b/source/wiz/_requirement.py
@@ -15,7 +15,7 @@ PUNCTUATION = Word("-_.")
 NAME = ALPHANUM + ZeroOrMore(ALPHANUM | (ZeroOrMore(PUNCTUATION) + ALPHANUM))
 NAME_SEPARATOR = L(wiz.symbol.NAMESPACE_SEPARATOR)
 IDENTIFIER = Combine(
-    Optional(Optional(NAME) + NAME_SEPARATOR) + NAME
+    ZeroOrMore(Optional(NAME) + NAME_SEPARATOR) + NAME
 )
 
 packaging.requirements.REQUIREMENT = (

--- a/source/wiz/command_line.py
+++ b/source/wiz/command_line.py
@@ -638,6 +638,28 @@ def wiz_view(click_context, **kwargs):
     is_flag=True,
     default=False
 )
+@click.option(
+    "-mc", "--max-combinations",
+    help=(
+        "Maximum number of combinations which can be generated from "
+        "conflicting variants during the context resolution process."
+    ),
+    default=_CONFIG.get("resolver", {}).get("maximum_combinations"),
+    type=int,
+    metavar="NUMBER",
+    show_default=True
+)
+@click.option(
+    "-ma", "--max-attempts",
+    help=(
+        "Maximum number of attempts to resolve the context before raising an "
+        "error."
+    ),
+    default=_CONFIG.get("resolver", {}).get("maximum_attempts"),
+    type=int,
+    metavar="NUMBER",
+    show_default=True
+)
 @click.argument(
     "requests",
     nargs=-1,
@@ -660,6 +682,8 @@ def wiz_use(click_context, **kwargs):
             list(kwargs["requests"]), definition_mapping,
             ignore_implicit=ignore_implicit,
             environ_mapping=environ_mapping,
+            maximum_combinations=kwargs["max_combinations"],
+            maximum_attempts=kwargs["max_attempts"],
         )
 
         # Only view the resolved context without spawning a shell nor
@@ -667,6 +691,10 @@ def wiz_use(click_context, **kwargs):
         if kwargs["view"]:
             display_registries(wiz_context["registries"])
             display_resolved_context(wiz_context)
+
+        # Do not execute any command if history is being recorded.
+        elif not kwargs["view"] and click_context.obj["recording_path"]:
+            pass
 
         # If no commands are indicated, spawn a shell.
         elif len(extra_arguments) == 0:
@@ -720,6 +748,28 @@ def wiz_use(click_context, **kwargs):
     is_flag=True,
     default=False
 )
+@click.option(
+    "-mc", "--max-combinations",
+    help=(
+        "Maximum number of combinations which can be generated from "
+        "conflicting variants during the context resolution process."
+    ),
+    default=_CONFIG.get("resolver", {}).get("maximum_combinations"),
+    type=int,
+    metavar="NUMBER",
+    show_default=True
+)
+@click.option(
+    "-ma", "--max-attempts",
+    help=(
+        "Maximum number of attempts to resolve the context before raising an "
+        "error."
+    ),
+    default=_CONFIG.get("resolver", {}).get("maximum_attempts"),
+    type=int,
+    metavar="NUMBER",
+    show_default=True
+)
 @click.argument(
     "request",
     nargs=1,
@@ -747,6 +797,8 @@ def wiz_run(click_context, **kwargs):
             [request], definition_mapping,
             ignore_implicit=ignore_implicit,
             environ_mapping=environ_mapping,
+            maximum_combinations=kwargs["max_combinations"],
+            maximum_attempts=kwargs["max_attempts"],
         )
 
         # Only view the resolved context without spawning a shell nor
@@ -754,6 +806,10 @@ def wiz_run(click_context, **kwargs):
         if kwargs["view"]:
             display_registries(wiz_context["registries"])
             display_resolved_context(wiz_context)
+
+        # Do not execute any command if history is being recorded.
+        elif not kwargs["view"] and click_context.obj["recording_path"]:
+            pass
 
         else:
             command_elements = wiz.resolve_command(

--- a/source/wiz/definition.py
+++ b/source/wiz/definition.py
@@ -571,6 +571,15 @@ class Definition(object):
         # Store values that needs to be constructed.
         self._cache = {}
 
+    def __repr__(self):
+        """Representing a Definition."""
+        return (
+            "<Definition id='{0}' version='{1}'>".format(
+                self.qualified_identifier,
+                self.version
+            )
+        )
+
     @property
     def path(self):
         """Return path to definition if available.

--- a/source/wiz/definition.py
+++ b/source/wiz/definition.py
@@ -319,7 +319,7 @@ def _guess_qualified_identifier(
 
     # If more than one namespace is available, attempt to use counter to only
     # keep those which are used the most.
-    if len(_namespaces) > 1 and max_occurrence > 1:
+    if len(_namespaces) > 1 and max_occurrence > 0:
         _namespaces = [
             namespace for namespace in _namespaces
             if namespace_counter[namespace] == max_occurrence

--- a/source/wiz/exception.py
+++ b/source/wiz/exception.py
@@ -8,16 +8,13 @@ import wiz.utility
 class WizError(Exception):
     """Base class for Wiz specific errors."""
 
-    default_message = "Unspecified Wiz error occurred."
-
-    def __init__(self, message=None):
+    def __init__(self, message):
         """Initialize with *message*.
 
-        :param message: Message to display instead of :attr:`default_message`.
-            Default is None.
+        :param message: Message describing the issue.
 
         """
-        self.message = message or self.default_message
+        self.message = message
         self.traceback = traceback.format_exc()
 
     def __str__(self):

--- a/source/wiz/exception.py
+++ b/source/wiz/exception.py
@@ -127,7 +127,7 @@ class GraphResolutionError(WizError):
 class GraphConflictsError(GraphResolutionError):
     """Raise when unsolvable conflicts are found in the graph."""
 
-    def __init__(self, conflicts, latest=True):
+    def __init__(self, conflicts):
         """Initialize with a list of conflict mappings.
 
         :param conflicts: List of conflict mappings which should be in the
@@ -149,16 +149,8 @@ class GraphConflictsError(GraphResolutionError):
                     ...
                 ]
 
-        :param latest: Indicate whether conflicts raised haven't been
-            found before. Default is True.
-
         """
-        self.latest = latest
         self.conflicts = conflicts
-        self.parents = set(
-            identifier for mapping in conflicts
-            for identifier in mapping["identifiers"]
-        )
 
         def _format(mapping):
             """Display conflicting *mapping*."""

--- a/source/wiz/exception.py
+++ b/source/wiz/exception.py
@@ -76,6 +76,18 @@ class DefinitionError(WizError):
         super(DefinitionError, self).__init__(message=message)
 
 
+class PackageError(WizError):
+    """Raise when a package is incorrect."""
+
+    def __init__(self, message):
+        """Initialize with *message*.
+
+        :param message: Message describing the issue.
+
+        """
+        super(PackageError, self).__init__(message=message)
+
+
 class RequirementError(WizError):
     """Raise when a requirement is incorrect."""
 

--- a/source/wiz/graph.py
+++ b/source/wiz/graph.py
@@ -1053,15 +1053,15 @@ def extract_conflicting_requirements(graph, nodes):
 class Graph(object):
     """Package dependency Graph.
 
-    Requested packages are added recursively as :class:`Node` instance from
+    Requested packages are added recursively as :class:`Node` instances from
     :meth:`requirements <Graph.update_from_requirements>` or :meth:`instances
     <Graph.update_from_package>`::
 
         >>> graph = Graph(resolver)
         >>> graph.update_from_requirements([Requirement("A >=1, <2")])
 
-    Dependent requirements are traversed using a `Breadth-first search
-    <https://en.wikipedia.org/wiki/Breadth-first_search>`_ algorithm so that
+    Dependent requirements are traversed using a `Breadth-first
+    <https://en.wikipedia.org/wiki/Breadth-first_search>`_ approach so that
     potential errors are recorded in coherent order.
 
     When a packages cannot be extracted from a requirement, errors are recorded
@@ -1088,7 +1088,7 @@ class Graph(object):
 
     """
 
-    #: Identify the root of the graph
+    #: Identify the root of the graph.
     ROOT = "root"
 
     def __init__(self, resolver):
@@ -1170,7 +1170,7 @@ class Graph(object):
         """Return all nodes in the graph.
 
         :param definition_identifier: Provide qualified identifier of a
-            definition whose node must belong to. Default is None which means
+            definition whose nodes must belong to. Default is None which means
             that nodes belonging to any definitions will be returned.
 
         :return: List of :class:`Node` instances.
@@ -1373,7 +1373,7 @@ class Graph(object):
         to graph accordingly. The process will be repeated recursively for
         dependent requirements from newly created packages.
 
-        :param requirements: List of class:`packaging.requirements.Requirement`
+        :param requirements: List of :class:`packaging.requirements.Requirement`
             instances ordered from the most important to the least important.
 
         :param detached: Indicate whether :class:`Node` instances created for
@@ -1415,7 +1415,7 @@ class Graph(object):
         :class:`Node` instances. The process will be repeated recursively for
         dependent requirements from newly created packages.
 
-        :param package: Instance of class:`wiz.package.Package`.
+        :param package: Instance of :class:`wiz.package.Package`.
 
         :param requirement: Instance of
             :class:`packaging.requirements.Requirement` which led to the

--- a/source/wiz/graph.py
+++ b/source/wiz/graph.py
@@ -949,8 +949,8 @@ def combined_requirements(graph, nodes):
             elif requirement.name != _requirement.name:
                 raise wiz.exception.GraphResolutionError(
                     "Impossible to combine requirements with different names "
-                    "['{}' and '{}'].".format(
-                        requirement.name, _requirement.name
+                    "[{}].".format(
+                        ", ".join(sorted([requirement.name, _requirement.name]))
                     )
                 )
 

--- a/source/wiz/graph.py
+++ b/source/wiz/graph.py
@@ -2133,7 +2133,7 @@ class Combination(object):
 
         wiz.history.record_action(
             wiz.symbol.GRAPH_ERROR_IDENTIFICATION_ACTION,
-            graph=self._graph, errors=error_mapping.keys()
+            graph=self._graph, errors=list(error_mapping.keys())
         )
 
         raise wiz.exception.GraphInvalidNodesError(error_mapping)

--- a/source/wiz/graph.py
+++ b/source/wiz/graph.py
@@ -2073,7 +2073,7 @@ class Combination(object):
         distance to the :attr:`root <Graph.ROOT>` level of the graph, the node
         identifier is used.
 
-        :return: Sorted list of :class:~wiz.package.Package` instances.
+        :return: Sorted list of :class:wiz.package.Package` instances.
 
         """
         distance_mapping = self._fetch_distance_mapping()

--- a/source/wiz/graph.py
+++ b/source/wiz/graph.py
@@ -120,7 +120,9 @@ class Resolver(object):
         )
 
         # Update the graph.
-        graph.update_from_requirements(requirements, graph.ROOT)
+        graph.update_from_requirements(
+            requirements, parent_identifier=graph.ROOT
+        )
 
         self.reset_combinations(graph)
 

--- a/source/wiz/graph.py
+++ b/source/wiz/graph.py
@@ -179,7 +179,7 @@ class Resolver(object):
 
         # Initialize combinations or simply add graph to iterator.
         if not self.extract_combinations(graph):
-            self._iterator = iter([VariantCombination(graph, copy_data=False)])
+            self._iterator = iter([Combination(graph, copy_data=False)])
 
     def extract_combinations(self, graph):
         variant_groups = graph.conflicting_variant_groups()
@@ -510,7 +510,7 @@ def generate_variant_combinations(graph, variant_groups):
     for combination in itertools.product(*_groups):
         _identifiers = [_id for _group in combination for _id in _group]
 
-        yield VariantCombination(
+        yield Combination(
             graph, nodes_to_remove=set([
                 _id for _id in identifiers
                 if _id not in _identifiers
@@ -1691,7 +1691,7 @@ class StoredNode(object):
         }
 
 
-class VariantCombination(object):
+class Combination(object):
     """Combination of a Package dependency Graph.
 
     This object operates an initial pruning process on a :class:`Graph` instance
@@ -1699,7 +1699,7 @@ class VariantCombination(object):
     preserved::
 
         >>> group = ["A[V3]", "A[V2]", "A[V1]"]
-        >>> combination = VariantCombination(graph, nodes_to_remove=group[1:])
+        >>> combination = Combination(graph, nodes_to_remove=group[1:])
 
     .. note::
 
@@ -1710,17 +1710,17 @@ class VariantCombination(object):
     steps:
 
     * Conflicting versions must be :meth:`resolved
-      <VariantCombination.resolve_conflicts>`::
+      <Combination.resolve_conflicts>`::
 
         >>> combination.resolve_conflicts()
 
     * Remaining nodes must be :meth:`validated
-      <VariantCombination.validate>`::
+      <Combination.validate>`::
 
         >>> combination.validate()
 
     * If previous stages did not raise any error, resolved packages can be
-      :meth:`extracted <VariantCombination.extract_packages>`::
+      :meth:`extracted <Combination.extract_packages>`::
 
         >>> combination.extract_packages()
 
@@ -1729,7 +1729,7 @@ class VariantCombination(object):
     """
 
     def __init__(self, graph, nodes_to_remove=None, copy_data=True):
-        """Initialize VariantCombination.
+        """Initialize Combination.
 
         :param graph: Instance of :class:`Graph`.
 
@@ -1741,7 +1741,7 @@ class VariantCombination(object):
             prevent mutating it. Default is True.
 
         """
-        self._logger = wiz.logging.Logger(__name__ + ".VariantCombination")
+        self._logger = wiz.logging.Logger(__name__ + ".Combination")
 
         wiz.history.record_action(
             wiz.symbol.GRAPH_COMBINATION_EXTRACTION_ACTION,

--- a/source/wiz/graph.py
+++ b/source/wiz/graph.py
@@ -1493,29 +1493,6 @@ class Node(object):
         )
 
     @property
-    def identifier(self):
-        """Return identifier of the node.
-
-        :return: String value (e.g. "foo==0.1.0").
-
-        .. note::
-
-            The node identifier is the same as the embedded package instance
-            identifier.
-
-        """
-        return self._package.identifier
-
-    @property
-    def definition(self):
-        """Return definition within embedded package instance.
-
-        :return: Instance of :class:`wiz.definition.Definition`.
-
-        """
-        return self._package.definition
-
-    @property
     def package(self):
         """Return embedded package instance.
 
@@ -1523,6 +1500,24 @@ class Node(object):
 
         """
         return self._package
+
+    @property
+    def identifier(self):
+        """Return identifier of the embedded package instance.
+
+        :return: String value (e.g. "foo==0.1.0").
+
+        """
+        return self._package.identifier
+
+    @property
+    def definition(self):
+        """Return definition of embedded package instance.
+
+        :return: Instance of :class:`wiz.definition.Definition`.
+
+        """
+        return self._package.definition
 
     @property
     def parent_identifiers(self):
@@ -1610,14 +1605,9 @@ class StoredNode(object):
 
     @property
     def identifier(self):
-        """Return identifier of the stored node.
+        """Return identifier of the embedded package instance.
 
         :return: String value (e.g. "foo==0.1.0").
-
-        .. note::
-
-            The node identifier is the same as the embedded package instance
-            identifier.
 
         """
         return self._package.identifier
@@ -1907,11 +1897,11 @@ class Combination(object):
             and distance_mapping.get(_id, {}).get("distance") is not None
         )
 
-        def _compare(identifier):
+        def _compare(_identifier):
             """Sort identifiers per distance and identifier."""
             return (
-                distance_mapping[identifier]["distance"],
-                identifier
+                distance_mapping[_identifier]["distance"],
+                _identifier
             )
 
         # Update order by distance.
@@ -2054,7 +2044,7 @@ class Combination(object):
         distance to the :attr:`root <Graph.ROOT>` level of the graph, the node
         identifier is used.
 
-        :return: Sorted list of :class:wiz.package.Package` instances.
+        :return: Sorted list of :class:`wiz.package.Package` instances.
 
         """
         distance_mapping = self._fetch_distance_mapping()

--- a/source/wiz/graph.py
+++ b/source/wiz/graph.py
@@ -135,7 +135,7 @@ class Resolver(object):
 
         while True:
             combination = self.fetch_next_combination()
-            if combination is None or nb_failures > self._maximum_attempts:
+            if combination is None or nb_failures >= self._maximum_attempts:
                 latest_error.message = (
                     "Failed to resolve graph at combination #{}:\n\n"
                     "{}".format(nb_failures, latest_error.message)

--- a/source/wiz/graph.py
+++ b/source/wiz/graph.py
@@ -1596,9 +1596,7 @@ class Graph(object):
             is the importance of the link. Default is 1.
 
         """
-        identifier = package.identifier
-
-        if not self.exists(identifier):
+        if not self.exists(package.identifier):
 
             try:
                 # Do not add node to the graph if conditions are unprocessed.
@@ -1623,7 +1621,7 @@ class Graph(object):
                 for index, _requirement in enumerate(package.requirements):
                     queue.put({
                         "requirement": _requirement,
-                        "parent_identifier": identifier,
+                        "parent_identifier": package.identifier,
                         "weight": index + 1
                     })
 
@@ -1635,9 +1633,9 @@ class Graph(object):
 
         else:
             # Update variant mapping if necessary
-            self._update_variant_mapping(identifier)
+            self._update_variant_mapping(package.identifier)
 
-        node = self._node_mapping[identifier]
+        node = self._node_mapping[package.identifier]
 
         if parent_identifier is not None:
             node.add_parent(parent_identifier)
@@ -1656,21 +1654,20 @@ class Graph(object):
         :param package: Instance of :class:`wiz.package.Package`.
 
         """
-        identifier = package.identifier
-
-        self._logger.debug("Adding package: {}".format(identifier))
-        self._node_mapping[identifier] = Node(package)
+        self._logger.debug("Adding package: {}".format(package.identifier))
+        self._node_mapping[package.identifier] = Node(package)
 
         # Record node identifiers per package to identify conflicts.
         _definition_id = package.definition.qualified_identifier
         self._identifiers_per_definition.setdefault(_definition_id, set())
-        self._identifiers_per_definition[_definition_id].add(identifier)
+        self._identifiers_per_definition[_definition_id].add(package.identifier)
 
         # Record variant per unique key identifier if necessary.
-        self._update_variant_mapping(identifier)
+        self._update_variant_mapping(package.identifier)
 
         wiz.history.record_action(
-            wiz.symbol.GRAPH_NODE_CREATION_ACTION, graph=self, node=identifier
+            wiz.symbol.GRAPH_NODE_CREATION_ACTION,
+            graph=self, node=package.identifier
         )
 
     def _update_variant_mapping(self, identifier):

--- a/source/wiz/graph.py
+++ b/source/wiz/graph.py
@@ -56,11 +56,11 @@ class Resolver(object):
         :param maximum_combinations: Maximum number of combinations which can be
             generated from conflicting variants. Default is None, which means
             that the default value will be picked from the :ref:`configuration
-            <configuration`.
+            <configuration>`.
 
         :param maximum_attempts: Maximum number of resolution attempts before
             raising an error. Default is None, which means  that the default
-            value will be picked from the :ref:`configuration <configuration`.
+            value will be picked from the :ref:`configuration <configuration>`.
 
         """
         self._logger = wiz.logging.Logger(__name__ + ".Resolver")

--- a/source/wiz/graph.py
+++ b/source/wiz/graph.py
@@ -1848,19 +1848,19 @@ class Graph(object):
 
         """
         return {
-            "node_mapping": {
+            "nodes": {
                 identifier: node.data() for identifier, node
                 in self._node_mapping.items()
             },
-            "link_mapping": copy.deepcopy(self._link_mapping),
+            "links": copy.deepcopy(self._link_mapping),
+            "errors": {
+                identifier: errors for identifier, errors
+                in self._error_mapping.items()
+            },
             "conditioned_nodes": [
                 stored_node.data() for stored_node
                 in self._conditioned_nodes
             ],
-            "error_mapping": {
-                identifier: errors for identifier, errors
-                in self._error_mapping.items()
-            }
         }
 
 

--- a/source/wiz/graph.py
+++ b/source/wiz/graph.py
@@ -1809,7 +1809,7 @@ class Combination(object):
         circular_conflicts = set()
 
         # Sort conflicts per distance to ensure breath-first resolution.
-        remaining_conflicts = self._update_conflict_queue(conflicts)
+        remaining_conflicts = self._update_conflict_queue([conflicts])
 
         while len(remaining_conflicts) > 0:
             conflict_identifier = remaining_conflicts.popleft()
@@ -1866,11 +1866,11 @@ class Combination(object):
                 # Update list of remaining conflicts if necessary.
                 if updated:
                     remaining_conflicts = self._update_conflict_queue(
-                        remaining_conflicts, self._graph.conflicting(),
+                        [remaining_conflicts, self._graph.conflicting()],
                         circular_conflicts=circular_conflicts
                     )
 
-    def _update_conflict_queue(self, *args, circular_conflicts=None):
+    def _update_conflict_queue(self, iterables, circular_conflicts=None):
         """Create new queue with conflicting node identifier lists.
 
         Duplicated identifiers are removed and all conflicting node identifiers
@@ -1882,7 +1882,7 @@ class Combination(object):
         Node identifier included in the *circular_conflicts* set will be sorted
         at the very end of the queue to be treated last.
 
-        :param args: Lists of conflicting node identifier.
+        :param iterables: Lists of conflicting node identifier.
 
         :param circular_conflicts: Set of conflicted node identifier which have
             conflicting parents.
@@ -1902,9 +1902,9 @@ class Combination(object):
         # identifiers flagged as circular conflicts so it can be added at the
         # end of the queue.
         identifiers = set(
-            identifier for _identifiers in args for identifier in _identifiers
-            if identifier not in circular_conflicts
-            and distance_mapping.get(identifier, {}).get("distance") is not None
+            _id for _identifiers in iterables for _id in _identifiers
+            if _id not in circular_conflicts
+            and distance_mapping.get(_id, {}).get("distance") is not None
         )
 
         def _compare(identifier):

--- a/source/wiz/graph.py
+++ b/source/wiz/graph.py
@@ -1839,22 +1839,19 @@ class Combination(object):
                 continue
 
             # Identify group of nodes conflicting with this node.
-            conflicting_nodes = self._graph.nodes(
+            nodes = self._graph.nodes(
                 definition_identifier=node.definition.qualified_identifier
             )
-            if len(conflicting_nodes) == 0:
+            if len(nodes) == 0:
                 continue
 
             # Compute combined requirements from all conflicting nodes.
-            requirement = combined_requirements(
-                self._graph, [node] + conflicting_nodes
-            )
+            requirement = combined_requirements(self._graph, nodes)
 
             # Query common packages from this combined requirements.
             try:
-                packages = self._extract_packages(
-                    requirement, [node] + conflicting_nodes
-                )
+                packages = self._extract_packages(requirement, nodes)
+
             except wiz.exception.GraphConflictsError as error:
                 # Push conflict at the end of the queue if it has conflicting
                 # parents that should be handled first.
@@ -1880,7 +1877,7 @@ class Combination(object):
 
                 # Update the graph if necessary
                 updated = self._add_packages_to_graph(
-                    packages, requirement, conflicting_nodes
+                    packages, requirement, nodes
                 )
 
                 # Relink node parents to package identifiers. It needs to be
@@ -2002,7 +1999,7 @@ class Combination(object):
         # Concatenate conflict lists while ignoring unreachable nodes and
         # identifiers flagged as circular conflicts so it can be added at the
         # end of the queue.
-        identifiers = (
+        identifiers = set(
             identifier for _identifiers in args for identifier in _identifiers
             if identifier not in circular_conflicts
             and distance_mapping.get(identifier, {}).get("distance") is not None

--- a/source/wiz/graph.py
+++ b/source/wiz/graph.py
@@ -1883,10 +1883,11 @@ class Combination(object):
                 self.prune_graph()
 
                 # Update list of remaining conflicts if necessary.
-                remaining_conflicts = self._update_conflict_queue(
-                    remaining_conflicts, self._graph.conflicting(),
-                    circular_conflicts=circular_conflicts
-                )
+                if updated:
+                    remaining_conflicts = self._update_conflict_queue(
+                        remaining_conflicts, self._graph.conflicting(),
+                        circular_conflicts=circular_conflicts
+                    )
 
     def _update_conflict_queue(self, *args, circular_conflicts=None):
         """Create new queue with conflicting node identifier lists.

--- a/source/wiz/graph.py
+++ b/source/wiz/graph.py
@@ -2054,7 +2054,6 @@ class Combination(object):
 
         except wiz.exception.RequestNotFound:
             conflicts = extract_conflicting_requirements(self._graph, nodes)
-            print(nodes, conflicts)
             parents = set(_id for m in conflicts for _id in m["identifiers"])
 
             # Push conflict at the end of the queue if it has conflicting

--- a/source/wiz/graph.py
+++ b/source/wiz/graph.py
@@ -2237,7 +2237,9 @@ class Combination(object):
 
         """
         if self._memoized_distance_mapping is None or force_update:
-            self._memoized_distance_mapping = compute_distance_mapping(self._graph)
+            self._memoized_distance_mapping = compute_distance_mapping(
+                self._graph
+            )
 
         return self._memoized_distance_mapping
 

--- a/source/wiz/graph.py
+++ b/source/wiz/graph.py
@@ -1914,7 +1914,7 @@ class Node(object):
         """Return corresponding dictionary."""
         return {
             "package": self._package.data(),
-            "parents": list(self._parent_identifiers)
+            "parents": sorted(self._parent_identifiers)
         }
 
 

--- a/source/wiz/graph.py
+++ b/source/wiz/graph.py
@@ -1733,7 +1733,7 @@ class VariantCombination(object):
 
         :param graph: Instance of :class:`Graph`.
 
-        :param nodes_to_remove: List of node identifier from a group of
+        :param nodes_to_remove: Set of node identifier from a group of
             conflicting variants which will be removed from the *graph*. Default
             is None which means that no node will be removed from the *graph*.
 

--- a/source/wiz/graph.py
+++ b/source/wiz/graph.py
@@ -719,15 +719,15 @@ class GraphCombination(object):
         """
         while True:
             # Remove all unreachable nodes if the graph has been updated.
-            if not self._trim_unreachable_from_graph():
+            if not self._trim_unreachable_nodes():
                 return
 
             # Search and trim invalid nodes from graph if conditions are no
             # longer fulfilled. Several passes might be necessary.
-            if not self._trim_unfulfilled_conditions_from_graph():
+            if not self._trim_unfulfilled_conditions():
                 return
 
-    def _trim_unreachable_from_graph(self):
+    def _trim_unreachable_nodes(self):
         distance_mapping = self._fetch_distance_mapping(force_update=True)
 
         nodes_removed = False
@@ -740,7 +740,7 @@ class GraphCombination(object):
 
         return nodes_removed
 
-    def _trim_unfulfilled_conditions_from_graph(self):
+    def _trim_unfulfilled_conditions(self):
         needs_update = True
         nodes_removed = []
 

--- a/source/wiz/graph.py
+++ b/source/wiz/graph.py
@@ -1848,19 +1848,19 @@ class Graph(object):
 
         """
         return {
-            "nodes": {
+            "node_mapping": {
                 identifier: node.data() for identifier, node
                 in self._node_mapping.items()
             },
-            "links": copy.deepcopy(self._link_mapping),
-            "errors": {
-                identifier: errors for identifier, errors
-                in self._error_mapping.items()
-            },
+            "link_mapping": copy.deepcopy(self._link_mapping),
             "conditioned_nodes": [
                 stored_node.data() for stored_node
                 in self._conditioned_nodes
             ],
+            "error_mapping": {
+                identifier: errors for identifier, errors
+                in self._error_mapping.items()
+            }
         }
 
 

--- a/source/wiz/graph.py
+++ b/source/wiz/graph.py
@@ -2166,7 +2166,6 @@ class Combination(object):
         nodes_removed = []
 
         while needs_update:
-            distance_mapping = self._fetch_distance_mapping(force_update=True)
             needs_update = False
 
             for stored_node in self._graph.conditioned_nodes():
@@ -2178,10 +2177,7 @@ class Combination(object):
                 for requirement in stored_node.package.conditions:
                     identifiers = self._graph.find(requirement)
 
-                    if len(identifiers) == 0 or any(
-                        distance_mapping.get(_id, {}).get("distance") is None
-                        for _id in identifiers
-                    ):
+                    if len(identifiers) == 0:
                         self._logger.debug(
                             "Remove '{}' as conditions are no longer "
                             "fulfilled".format(stored_node.identifier)

--- a/source/wiz/graph.py
+++ b/source/wiz/graph.py
@@ -799,7 +799,7 @@ def compute_distance_mapping(graph):
 
     """
     logger = wiz.logging.Logger(__name__ + ".compute_distance_mapping")
-    logger.debug("Compute distance mapping...")
+    logger.debug("Compute distance mapping.")
 
     # Initiate mapping
     distance_mapping = {

--- a/source/wiz/history.py
+++ b/source/wiz/history.py
@@ -130,10 +130,17 @@ def record_action(identifier, **kwargs):
 
 
 def _json_default(_object):
-    """Override :func:`JSONEncoder.default` to serialize all objects."""
+    """Override :meth:`json.JSONEncoder.default` to serialize all objects.
+
+    Usage::
+
+        >>> import json
+        >>> json.dumps(_object, default=_json_default).encode("utf-8")
+
+    """
     from wiz.definition import Definition
     from wiz.package import Package
-    from wiz.graph import Graph
+    from wiz.graph import Graph, Node, StoredNode
 
     if isinstance(_object, Definition):
         data = _object.data()
@@ -141,7 +148,7 @@ def _json_default(_object):
         data["registry_path"] = _object.registry_path
         return data
 
-    if isinstance(_object, (Graph, Package)):
+    if isinstance(_object, (Graph, Graph, Node, StoredNode, Package)):
         return _object.data()
 
     elif isinstance(_object, (Requirement, Version)):

--- a/source/wiz/package.py
+++ b/source/wiz/package.py
@@ -293,6 +293,26 @@ class Package(object):
         # been processed
         self._conditions_processed = False
 
+        if self._variant_index is None and len(self._definition.variants) > 0:
+            raise wiz.exception.PackageError(
+                "Package cannot be created from definition '{}' as no variant "
+                "index is defined.".format(
+                    self._definition.qualified_identifier
+                )
+            )
+
+        if (
+            self._variant_index is not None
+            and self._variant_index + 1 > len(self._definition.variants)
+        ):
+            raise wiz.exception.PackageError(
+                "Package cannot be created from definition '{}' with variant "
+                "index #{}.".format(
+                    self._definition.qualified_identifier,
+                    self._variant_index
+                )
+            )
+
     @property
     def definition(self):
         """Return definition used to create package.

--- a/source/wiz/package.py
+++ b/source/wiz/package.py
@@ -282,6 +282,9 @@ class Package(object):
         :param variant_index: Index number of the variant which will be used to
             create package instance if applicable. Default is None.
 
+        :raise: :exc:`wiz.exception.PackageError` if the variant index is
+            missing or incorrect.
+
         """
         self._definition = definition
         self._variant_index = variant_index

--- a/source/wiz/package.py
+++ b/source/wiz/package.py
@@ -313,6 +313,10 @@ class Package(object):
                 )
             )
 
+    def __repr__(self):
+        """Representing a Package."""
+        return "<Package id='{0}'>".format(self.identifier)
+
     @property
     def definition(self):
         """Return definition used to create package.

--- a/source/wiz/package_data/config.toml
+++ b/source/wiz/package_data/config.toml
@@ -5,6 +5,10 @@ paths=[]
 initial={}
 passthrough=[]
 
+[resolver]
+maximum_combinations=5
+maximum_attempts=15
+
 [command]
 max_content_width=90
 verbosity="info"

--- a/source/wiz/package_data/config.toml
+++ b/source/wiz/package_data/config.toml
@@ -6,7 +6,7 @@ initial={}
 passthrough=[]
 
 [resolver]
-maximum_combinations=5
+maximum_combinations=10
 maximum_attempts=15
 
 [command]

--- a/source/wiz/registry.py
+++ b/source/wiz/registry.py
@@ -172,10 +172,7 @@ def install_to_path(definitions, registry_path, overwrite=False):
 
     # Fail if overwrite is False and some definition paths exist in registry.
     if len(existing_definition_map) > 0 and overwrite is False:
-        raise wiz.exception.DefinitionsExist([
-            wiz.utility.compute_label(definition)
-            for definition in existing_definition_map.values()
-        ])
+        raise wiz.exception.DefinitionsExist(existing_definition_map.values())
 
     # Release definitions
     for definition in _definitions:

--- a/source/wiz/utility.py
+++ b/source/wiz/utility.py
@@ -426,10 +426,13 @@ def encode(element):
 
     :param element: Content to encode.
 
+    :return: Encoded string.
+
     :raise: :exc:`TypeError` if *element* is not JSON serializable.
 
     """
-    return base64.b64encode(zlib.compress(ujson.dumps(element).encode("utf-8")))
+    serialized = ujson.dumps(element).encode("utf-8")
+    return base64.b64encode(zlib.compress(serialized)).decode("utf-8")
 
 
 def decode(element):

--- a/source/wiz/utility.py
+++ b/source/wiz/utility.py
@@ -616,7 +616,7 @@ def sanitize_requirement(requirement, package):
 
     :param requirement: Instance of :class:`packaging.requirements.Requirement`.
 
-    :param package: Instance of class:`wiz.package.Package`.
+    :param package: Instance of :class:`wiz.package.Package`.
 
     :return: new instance of :class:`packaging.requirements.Requirement`.
 
@@ -643,7 +643,7 @@ def match(requirement, package):
 
     :param requirement: Instance of :class:`packaging.requirements.Requirement`.
 
-    :param package: Instance of class:`wiz.package.Package`.
+    :param package: Instance of :class:`wiz.package.Package`.
 
     :return: Boolean value.
 

--- a/source/wiz/utility.py
+++ b/source/wiz/utility.py
@@ -705,3 +705,27 @@ def extract_namespace(requirement):
         namespace = None
 
     return namespace, identifier
+
+
+def check_conflicting_requirements(package1, package2):
+    """Check whether some requirements are conflicting between packages.
+
+    :param package1: Instance of :class:`wiz.package.Package`.
+
+    :param package2: Instance of :class:`wiz.package.Package` to compare
+        *package1* with.
+
+    :return: Boolean value.
+
+    """
+    mapping = {}
+
+    for requirement in package1.requirements + package2.requirements:
+        _requirement = mapping.get(requirement.name)
+        if _requirement is not None:
+            if not is_overlapping(requirement, _requirement):
+                return True
+
+        mapping[requirement.name] = requirement
+
+    return False

--- a/source/wiz/utility.py
+++ b/source/wiz/utility.py
@@ -210,9 +210,9 @@ def _update_maximum_version(version, ranges):
 
     Example::
 
-        >>> ranges = [((1, 2, 3), (1, 3, 0)), ((1, 3, 3), (1, 4))]
-        >>> _update_maximum_version((1, 2, 3), ranges)
-        >>> print(ranges)
+        >>> version_ranges = [((1, 2, 3), (1, 3, 0)), ((1, 3, 3), (1, 4))]
+        >>> _update_maximum_version((1, 2, 3), version_ranges)
+        >>> print(version_ranges)
         [((1, 2, 3), (1, 2, 3))]
 
     :param version: Tuple representing a version (e.g. (1,2,3)).
@@ -253,9 +253,9 @@ def _update_minimum_version(version, ranges):
 
     Example::
 
-        >>> ranges = [((1, 2, 3), (1, 3, 0)), ((1, 3, 3), (1, 4))]
-        >>> _update_minimum_version((1, 3, 3), ranges)
-        >>> print(ranges)
+        >>> version_ranges = [((1, 2, 3), (1, 3, 0)), ((1, 3, 3), (1, 4))]
+        >>> _update_minimum_version((1, 3, 3), version_ranges)
+        >>> print(version_ranges)
         [((1, 3, 3), (1, 4))]
 
     :param version: Tuple representing a version (e.g. (1,2,3)).
@@ -296,9 +296,9 @@ def _update_version_ranges(excluded, ranges):
 
     Example::
 
-        >>> ranges = [((1,2,3), (1,3,0)), ((1,3,3), (1,4))]
-        >>> _update_version_ranges(((1,2,3), (1,3,3)), ranges)
-        >>> print(ranges)
+        >>> version_ranges = [((1,2,3), (1,3,0)), ((1,3,3), (1,4))]
+        >>> _update_version_ranges(((1,2,3), (1,3,3)), version_ranges)
+        >>> print(version_ranges)
         [((1, 2, 3), (1, 2, 3)), ((1, 3, 3), (1, 4))]
 
     :param excluded: Tuple containing two ordered version release tuples (e.g.

--- a/test/integration/test_resolver.py
+++ b/test/integration/test_resolver.py
@@ -2937,7 +2937,7 @@ def test_scenario_39():
      |
      `--(B==7): B==7
 
-    Expected: B==7, A[V7]
+    Expected: B==1, A[V1]
 
     """
     definition_mapping = {
@@ -3010,9 +3010,9 @@ def test_scenario_39():
 
     resolver = wiz.graph.Resolver(definition_mapping)
     packages = resolver.compute_packages([
-        Requirement("A"), Requirement("B==7")
+        Requirement("A"), Requirement("B==1")
     ])
 
     assert len(packages) == 2
-    assert packages[0].identifier == "B==7"
-    assert packages[1].identifier == "A[V7]"
+    assert packages[0].identifier == "B==1"
+    assert packages[1].identifier == "A[V1]"

--- a/test/integration/test_resolver.py
+++ b/test/integration/test_resolver.py
@@ -9,9 +9,6 @@ import wiz.definition
 import wiz.graph
 from wiz.utility import Requirement
 
-#: Indicate whether spied call should be tested.
-_CHECK_SPIED_CALL = True
-
 
 @pytest.fixture(autouse=True)
 def reset_configuration(mocker):
@@ -22,109 +19,7 @@ def reset_configuration(mocker):
     wiz.config.fetch(refresh=True)
 
 
-@pytest.fixture()
-def spied_fetch_next_combination(mocker):
-    """Return spy mocker on 'wiz.graph.Resolver._fetch_next_combination'."""
-    return mocker.spy(wiz.graph.Resolver, "_fetch_next_combination")
-
-
-@pytest.fixture()
-def spied_compute_combination(mocker):
-    """Return spy mocker on 'wiz.graph.Resolver._compute_combination'."""
-    return mocker.spy(wiz.graph.Resolver, "_compute_combination")
-
-
-@pytest.fixture()
-def spied_fetch_distance_mapping(mocker):
-    """Return spy mocker on 'wiz.graph.Resolver._fetch_distance_mapping'."""
-    return mocker.spy(wiz.graph.Resolver, "_fetch_distance_mapping")
-
-
-@pytest.fixture()
-def spied_extract_combinations(mocker):
-    """Return spy mocker on 'wiz.graph.Resolver._extract_combinations'."""
-    return mocker.spy(wiz.graph.Resolver, "_extract_combinations")
-
-
-@pytest.fixture()
-def spied_resolve_conflicts(mocker):
-    """Return spy mocker on 'wiz.graph.Resolver._resolve_conflicts'."""
-    return mocker.spy(wiz.graph.Resolver, "_resolve_conflicts")
-
-
-@pytest.fixture()
-def spied_compute_distance_mapping(mocker):
-    """Return spy mocker on 'wiz.graph.compute_distance_mapping'."""
-    return mocker.spy(wiz.graph, "compute_distance_mapping")
-
-
-@pytest.fixture()
-def spied_generate_variant_combinations(mocker):
-    """Return spy mocker on 'wiz.graph.generate_variant_combinations'.
-    """
-    return mocker.spy(wiz.graph, "generate_variant_combinations")
-
-
-@pytest.fixture()
-def spied_trim_unreachable_from_graph(mocker):
-    """Return spy mocker on 'wiz.graph.trim_unreachable_from_graph'.
-    """
-    return mocker.spy(wiz.graph, "trim_unreachable_from_graph")
-
-
-@pytest.fixture()
-def spied_trim_invalid_from_graph(mocker):
-    """Return spy mocker on 'wiz.graph.trim_invalid_from_graph'.
-    """
-    return mocker.spy(wiz.graph, "trim_invalid_from_graph")
-
-
-@pytest.fixture()
-def spied_updated_by_distance(mocker):
-    """Return spy mocker on 'wiz.graph.updated_by_distance'."""
-    return mocker.spy(wiz.graph, "updated_by_distance")
-
-
-@pytest.fixture()
-def spied_extract_conflicting_nodes(mocker):
-    """Return spy mocker on 'wiz.graph.extract_conflicting_nodes'."""
-    return mocker.spy(wiz.graph, "extract_conflicting_nodes")
-
-
-@pytest.fixture()
-def spied_combined_requirements(mocker):
-    """Return spy mocker on 'wiz.graph.combined_requirements'."""
-    return mocker.spy(wiz.graph, "combined_requirements")
-
-
-@pytest.fixture()
-def spied_extract_conflicting_requirements(mocker):
-    """Return spy mocker on 'wiz.graph.extract_conflicting_requirements'."""
-    return mocker.spy(wiz.graph, "extract_conflicting_requirements")
-
-
-@pytest.fixture()
-def spied_extract_ordered_packages(mocker):
-    """Return spy mocker on 'wiz.graph.extract_ordered_packages'."""
-    return mocker.spy(wiz.graph, "extract_ordered_packages")
-
-
-def test_scenario_1(
-    spied_fetch_next_combination,
-    spied_compute_combination,
-    spied_fetch_distance_mapping,
-    spied_extract_combinations,
-    spied_resolve_conflicts,
-    spied_compute_distance_mapping,
-    spied_generate_variant_combinations,
-    spied_trim_unreachable_from_graph,
-    spied_trim_invalid_from_graph,
-    spied_updated_by_distance,
-    spied_extract_conflicting_nodes,
-    spied_combined_requirements,
-    spied_extract_conflicting_requirements,
-    spied_extract_ordered_packages
-):
+def test_scenario_1():
     """Compute packages for the following graph.
 
     Root
@@ -147,10 +42,7 @@ def test_scenario_1(
              |
              `--(F>=1): F==1.0.0
 
-    Expected: F==1.0.0, D==0.1.0, B==0.1.0, C==0.3.2, G==2.0.2, A==0.2.0
-
-    The position of 'D==0.1.0' / 'B==0.1.0' and 'C==0.3.2' / 'G==2.0.2' can
-    vary as they have similar priority numbers.
+    Expected: F==1.0.0, D==0.1.0, B==0.1.0, G==2.0.2, C==0.3.2, A==0.2.0
 
     """
     definition_mapping = {
@@ -233,53 +125,14 @@ def test_scenario_1(
 
     assert len(packages) == 6
     assert packages[0].identifier == "F==1.0.0"
-
-    # Order can vary cause both have priority of 3
-    assert packages[1].identifier in ["D==0.1.0", "B==0.1.0"]
-    assert packages[2].identifier in ["D==0.1.0", "B==0.1.0"]
-    assert packages[2] != packages[1]
-
-    # Order can vary cause both have priority of 2
-    assert packages[3].identifier in ["C==0.3.2", "G==2.0.2"]
-    assert packages[4].identifier in ["C==0.3.2", "G==2.0.2"]
-    assert packages[4] != packages[3]
-
+    assert packages[1].identifier == "D==0.1.0"
+    assert packages[2].identifier == "B==0.1.0"
+    assert packages[3].identifier == "G==2.0.2"
+    assert packages[4].identifier == "C==0.3.2"
     assert packages[5].identifier == "A==0.2.0"
 
-    # Check spied functions / methods
-    if _CHECK_SPIED_CALL:
-        assert spied_fetch_next_combination.call_count == 1
-        assert spied_compute_combination.call_count == 1
-        assert spied_fetch_distance_mapping.call_count == 6
-        assert spied_extract_combinations.call_count == 1
-        assert spied_resolve_conflicts.call_count == 1
-        assert spied_compute_distance_mapping.call_count == 3
-        assert spied_generate_variant_combinations.call_count == 0
-        assert spied_trim_unreachable_from_graph.call_count == 1
-        assert spied_trim_invalid_from_graph.call_count == 1
-        assert spied_updated_by_distance.call_count == 1
-        assert spied_extract_conflicting_nodes.call_count == 2
-        assert spied_combined_requirements.call_count == 1
-        assert spied_extract_conflicting_requirements.call_count == 0
-        assert spied_extract_ordered_packages.call_count == 1
 
-
-def test_scenario_2(
-    spied_fetch_next_combination,
-    spied_compute_combination,
-    spied_fetch_distance_mapping,
-    spied_extract_combinations,
-    spied_resolve_conflicts,
-    spied_compute_distance_mapping,
-    spied_generate_variant_combinations,
-    spied_trim_unreachable_from_graph,
-    spied_trim_invalid_from_graph,
-    spied_updated_by_distance,
-    spied_extract_conflicting_nodes,
-    spied_combined_requirements,
-    spied_extract_conflicting_requirements,
-    spied_extract_ordered_packages
-):
+def test_scenario_2():
     """Fail to compute packages for the following graph.
 
     Root
@@ -389,44 +242,12 @@ def test_scenario_2(
     assert (
         "The dependency graph could not be resolved due to the "
         "following requirement conflicts:\n"
-        "  * D >0.1.0 \t[B==0.1.0]\n"
-        "  * D ==0.1.0 \t[C==0.3.2]"
+        "  * ::D >0.1.0 \t[B==0.1.0]\n"
+        "  * ::D ==0.1.0 \t[C==0.3.2]"
     ) in str(error.value)
 
-    # Check spied functions / methods
-    if _CHECK_SPIED_CALL:
-        assert spied_fetch_next_combination.call_count == 2
-        assert spied_compute_combination.call_count == 1
-        assert spied_fetch_distance_mapping.call_count == 1
-        assert spied_extract_combinations.call_count == 1
-        assert spied_resolve_conflicts.call_count == 1
-        assert spied_compute_distance_mapping.call_count == 1
-        assert spied_generate_variant_combinations.call_count == 0
-        assert spied_trim_unreachable_from_graph.call_count == 0
-        assert spied_trim_invalid_from_graph.call_count == 0
-        assert spied_updated_by_distance.call_count == 1
-        assert spied_extract_conflicting_nodes.call_count == 1
-        assert spied_combined_requirements.call_count == 3
-        assert spied_extract_conflicting_requirements.call_count == 1
-        assert spied_extract_ordered_packages.call_count == 0
 
-
-def test_scenario_3(
-    spied_fetch_next_combination,
-    spied_compute_combination,
-    spied_fetch_distance_mapping,
-    spied_extract_combinations,
-    spied_resolve_conflicts,
-    spied_compute_distance_mapping,
-    spied_generate_variant_combinations,
-    spied_trim_unreachable_from_graph,
-    spied_trim_invalid_from_graph,
-    spied_updated_by_distance,
-    spied_extract_conflicting_nodes,
-    spied_combined_requirements,
-    spied_extract_conflicting_requirements,
-    spied_extract_ordered_packages
-):
+def test_scenario_3():
     """Compute packages for the following graph.
 
     In a situation with several solutions, the solution which guaranty the
@@ -477,40 +298,8 @@ def test_scenario_3(
     assert packages[0].identifier == "B==0.9.0"
     assert packages[1].identifier == "A==1.0.0"
 
-    # Check spied functions / methods
-    if _CHECK_SPIED_CALL:
-        assert spied_fetch_next_combination.call_count == 1
-        assert spied_compute_combination.call_count == 1
-        assert spied_fetch_distance_mapping.call_count == 10
-        assert spied_extract_combinations.call_count == 1
-        assert spied_resolve_conflicts.call_count == 1
-        assert spied_compute_distance_mapping.call_count == 3
-        assert spied_generate_variant_combinations.call_count == 0
-        assert spied_trim_unreachable_from_graph.call_count == 1
-        assert spied_trim_invalid_from_graph.call_count == 1
-        assert spied_updated_by_distance.call_count == 3
-        assert spied_extract_conflicting_nodes.call_count == 4
-        assert spied_combined_requirements.call_count == 3
-        assert spied_extract_conflicting_requirements.call_count == 0
-        assert spied_extract_ordered_packages.call_count == 1
 
-
-def test_scenario_4(
-    spied_fetch_next_combination,
-    spied_compute_combination,
-    spied_fetch_distance_mapping,
-    spied_extract_combinations,
-    spied_resolve_conflicts,
-    spied_compute_distance_mapping,
-    spied_generate_variant_combinations,
-    spied_trim_unreachable_from_graph,
-    spied_trim_invalid_from_graph,
-    spied_updated_by_distance,
-    spied_extract_conflicting_nodes,
-    spied_combined_requirements,
-    spied_extract_conflicting_requirements,
-    spied_extract_ordered_packages
-):
+def test_scenario_4():
     """Compute packages for the following graph.
 
     When only the identifier of a definition with several variants is required,
@@ -591,40 +380,8 @@ def test_scenario_4(
     assert packages[0].identifier == "B==4.0.0"
     assert packages[1].identifier == "A[V4]==1.0.0"
 
-    # Check spied functions / methods
-    if _CHECK_SPIED_CALL:
-        assert spied_fetch_next_combination.call_count == 1
-        assert spied_compute_combination.call_count == 1
-        assert spied_fetch_distance_mapping.call_count == 5
-        assert spied_extract_combinations.call_count == 1
-        assert spied_resolve_conflicts.call_count == 1
-        assert spied_compute_distance_mapping.call_count == 3
-        assert spied_generate_variant_combinations.call_count == 1
-        assert spied_trim_unreachable_from_graph.call_count == 1
-        assert spied_trim_invalid_from_graph.call_count == 1
-        assert spied_updated_by_distance.call_count == 0
-        assert spied_extract_conflicting_nodes.call_count == 0
-        assert spied_combined_requirements.call_count == 0
-        assert spied_extract_conflicting_requirements.call_count == 0
-        assert spied_extract_ordered_packages.call_count == 1
 
-
-def test_scenario_5(
-    spied_fetch_next_combination,
-    spied_compute_combination,
-    spied_fetch_distance_mapping,
-    spied_extract_combinations,
-    spied_resolve_conflicts,
-    spied_compute_distance_mapping,
-    spied_generate_variant_combinations,
-    spied_trim_unreachable_from_graph,
-    spied_trim_invalid_from_graph,
-    spied_updated_by_distance,
-    spied_extract_conflicting_nodes,
-    spied_combined_requirements,
-    spied_extract_conflicting_requirements,
-    spied_extract_ordered_packages
-):
+def test_scenario_5():
     """Compute packages for the following graph.
 
     When a specific variant of a definition is required, only one graph with
@@ -691,40 +448,8 @@ def test_scenario_5(
     assert packages[0].identifier == "B==1.0.0"
     assert packages[1].identifier == "A[V1]==1.0.0"
 
-    # Check spied functions / methods
-    if _CHECK_SPIED_CALL:
-        assert spied_fetch_next_combination.call_count == 1
-        assert spied_compute_combination.call_count == 1
-        assert spied_fetch_distance_mapping.call_count == 1
-        assert spied_extract_combinations.call_count == 1
-        assert spied_resolve_conflicts.call_count == 1
-        assert spied_compute_distance_mapping.call_count == 1
-        assert spied_generate_variant_combinations.call_count == 0
-        assert spied_trim_unreachable_from_graph.call_count == 0
-        assert spied_trim_invalid_from_graph.call_count == 0
-        assert spied_updated_by_distance.call_count == 0
-        assert spied_extract_conflicting_nodes.call_count == 0
-        assert spied_combined_requirements.call_count == 0
-        assert spied_extract_conflicting_requirements.call_count == 0
-        assert spied_extract_ordered_packages.call_count == 1
 
-
-def test_scenario_6(
-    spied_fetch_next_combination,
-    spied_compute_combination,
-    spied_fetch_distance_mapping,
-    spied_extract_combinations,
-    spied_resolve_conflicts,
-    spied_compute_distance_mapping,
-    spied_generate_variant_combinations,
-    spied_trim_unreachable_from_graph,
-    spied_trim_invalid_from_graph,
-    spied_updated_by_distance,
-    spied_extract_conflicting_nodes,
-    spied_combined_requirements,
-    spied_extract_conflicting_requirements,
-    spied_extract_ordered_packages
-):
+def test_scenario_6():
     """Compute packages for the following graph.
 
     Like the scenario 4, we end up with as many graph as there are variants. But
@@ -808,40 +533,8 @@ def test_scenario_6(
     assert packages[0].identifier == "B==2.0.0"
     assert packages[1].identifier == "A[V2]==1.0.0"
 
-    # Check spied functions / methods
-    if _CHECK_SPIED_CALL:
-        assert spied_fetch_next_combination.call_count == 3
-        assert spied_compute_combination.call_count == 3
-        assert spied_fetch_distance_mapping.call_count == 13
-        assert spied_extract_combinations.call_count == 1
-        assert spied_resolve_conflicts.call_count == 3
-        assert spied_compute_distance_mapping.call_count == 7
-        assert spied_generate_variant_combinations.call_count == 1
-        assert spied_trim_unreachable_from_graph.call_count == 3
-        assert spied_trim_invalid_from_graph.call_count == 3
-        assert spied_updated_by_distance.call_count == 2
-        assert spied_extract_conflicting_nodes.call_count == 2
-        assert spied_combined_requirements.call_count == 2
-        assert spied_extract_conflicting_requirements.call_count == 2
-        assert spied_extract_ordered_packages.call_count == 1
 
-
-def test_scenario_7(
-    spied_fetch_next_combination,
-    spied_compute_combination,
-    spied_fetch_distance_mapping,
-    spied_extract_combinations,
-    spied_resolve_conflicts,
-    spied_compute_distance_mapping,
-    spied_generate_variant_combinations,
-    spied_trim_unreachable_from_graph,
-    spied_trim_invalid_from_graph,
-    spied_updated_by_distance,
-    spied_extract_conflicting_nodes,
-    spied_combined_requirements,
-    spied_extract_conflicting_requirements,
-    spied_extract_ordered_packages
-):
+def test_scenario_7():
     """Compute packages for the following graph.
 
     The combined requirement of packages can lead to the addition of a different
@@ -907,40 +600,8 @@ def test_scenario_7(
     assert packages[1].identifier == "B==0.1.0"
     assert packages[2].identifier == "A==0.2.0"
 
-    # Check spied functions / methods
-    if _CHECK_SPIED_CALL:
-        assert spied_fetch_next_combination.call_count == 1
-        assert spied_compute_combination.call_count == 1
-        assert spied_fetch_distance_mapping.call_count == 12
-        assert spied_extract_combinations.call_count == 2
-        assert spied_resolve_conflicts.call_count == 1
-        assert spied_compute_distance_mapping.call_count == 4
-        assert spied_generate_variant_combinations.call_count == 0
-        assert spied_trim_unreachable_from_graph.call_count == 3
-        assert spied_trim_invalid_from_graph.call_count == 0
-        assert spied_updated_by_distance.call_count == 3
-        assert spied_extract_conflicting_nodes.call_count == 4
-        assert spied_combined_requirements.call_count == 4
-        assert spied_extract_conflicting_requirements.call_count == 0
-        assert spied_extract_ordered_packages.call_count == 1
 
-
-def test_scenario_8(
-    spied_fetch_next_combination,
-    spied_compute_combination,
-    spied_fetch_distance_mapping,
-    spied_extract_combinations,
-    spied_resolve_conflicts,
-    spied_compute_distance_mapping,
-    spied_generate_variant_combinations,
-    spied_trim_unreachable_from_graph,
-    spied_trim_invalid_from_graph,
-    spied_updated_by_distance,
-    spied_extract_conflicting_nodes,
-    spied_combined_requirements,
-    spied_extract_conflicting_requirements,
-    spied_extract_ordered_packages
-):
+def test_scenario_8():
     """Compute packages for the following graph.
 
     When conflicts parents are themselves conflicting, they should be discarded
@@ -959,9 +620,6 @@ def test_scenario_8(
              `--(C <1): C== 0.9.0
 
     Expected: A==0.9.0, C==0.9.0, B==0.1.0
-
-    The position of 'C==0.9.0' / 'B==0.1.0' can vary as they have similar
-    priority numbers.
 
     """
     definition_mapping = {
@@ -1003,47 +661,12 @@ def test_scenario_8(
     ])
 
     assert len(packages) == 3
-
-    assert packages[0].identifier in ["C==0.9.0", "B==0.1.0"]
-    assert packages[1].identifier in ["C==0.9.0", "B==0.1.0"]
-    assert packages[0] != packages[1]
-
+    assert packages[0].identifier == "C==0.9.0"
+    assert packages[1].identifier == "B==0.1.0"
     assert packages[2].identifier == "A==0.9.0"
 
-    # Check spied functions / methods
-    if _CHECK_SPIED_CALL:
-        assert spied_fetch_next_combination.call_count == 1
-        assert spied_compute_combination.call_count == 1
-        assert spied_fetch_distance_mapping.call_count == 9
-        assert spied_extract_combinations.call_count == 1
-        assert spied_resolve_conflicts.call_count == 1
-        assert spied_compute_distance_mapping.call_count == 3
-        assert spied_generate_variant_combinations.call_count == 0
-        assert spied_trim_unreachable_from_graph.call_count == 1
-        assert spied_trim_invalid_from_graph.call_count == 1
-        assert spied_updated_by_distance.call_count == 4
-        assert spied_extract_conflicting_nodes.call_count == 4
-        assert spied_combined_requirements.call_count == 4
-        assert spied_extract_conflicting_requirements.call_count == 2
-        assert spied_extract_ordered_packages.call_count == 1
 
-
-def test_scenario_9(
-    spied_fetch_next_combination,
-    spied_compute_combination,
-    spied_fetch_distance_mapping,
-    spied_extract_combinations,
-    spied_resolve_conflicts,
-    spied_compute_distance_mapping,
-    spied_generate_variant_combinations,
-    spied_trim_unreachable_from_graph,
-    spied_trim_invalid_from_graph,
-    spied_updated_by_distance,
-    spied_extract_conflicting_nodes,
-    spied_combined_requirements,
-    spied_extract_conflicting_requirements,
-    spied_extract_ordered_packages
-):
+def test_scenario_9():
     """Compute packages for the following graph.
 
     Like the scenario 8 with different order in the graph.
@@ -1060,7 +683,7 @@ def test_scenario_9(
              |
              `--(C>=1): C== 1.0.0
 
-    Expected: C==0.9.0, B==0.1.0, A==0.9.0
+    Expected: B==0.1.0, C==0.9.0, A==0.9.0
 
     """
     definition_mapping = {
@@ -1102,44 +725,12 @@ def test_scenario_9(
     ])
 
     assert len(packages) == 3
-    assert packages[0].identifier == "B==0.1.0"
-    assert packages[1].identifier == "C==0.9.0"
+    assert packages[0].identifier == "C==0.9.0"
+    assert packages[1].identifier == "B==0.1.0"
     assert packages[2].identifier == "A==0.9.0"
 
-    # Check spied functions / methods
-    if _CHECK_SPIED_CALL:
-        assert spied_fetch_next_combination.call_count == 1
-        assert spied_compute_combination.call_count == 1
-        assert spied_fetch_distance_mapping.call_count == 8
-        assert spied_extract_combinations.call_count == 1
-        assert spied_resolve_conflicts.call_count == 1
-        assert spied_compute_distance_mapping.call_count == 3
-        assert spied_generate_variant_combinations.call_count == 0
-        assert spied_trim_unreachable_from_graph.call_count == 1
-        assert spied_trim_invalid_from_graph.call_count == 1
-        assert spied_updated_by_distance.call_count == 2
-        assert spied_extract_conflicting_nodes.call_count == 4
-        assert spied_combined_requirements.call_count == 2
-        assert spied_extract_conflicting_requirements.call_count == 1
-        assert spied_extract_ordered_packages.call_count == 1
 
-
-def test_scenario_10(
-    spied_fetch_next_combination,
-    spied_compute_combination,
-    spied_fetch_distance_mapping,
-    spied_extract_combinations,
-    spied_resolve_conflicts,
-    spied_compute_distance_mapping,
-    spied_generate_variant_combinations,
-    spied_trim_unreachable_from_graph,
-    spied_trim_invalid_from_graph,
-    spied_updated_by_distance,
-    spied_extract_conflicting_nodes,
-    spied_combined_requirements,
-    spied_extract_conflicting_requirements,
-    spied_extract_ordered_packages
-):
+def test_scenario_10():
     """Compute packages for the following graph.
 
     Like the scenario 7, a new node is added to the graph during the conflict
@@ -1154,7 +745,7 @@ def test_scenario_10(
          |
          `--(A !=0.3.0): A==1.0.0
 
-    Expected: B==0.1.0, C[V3]==1.0.0, A==0.2.0
+    Expected: C[V3]==1.0.0, B==0.1.0, A==0.2.0
 
     """
     definition_mapping = {
@@ -1205,44 +796,12 @@ def test_scenario_10(
     ])
 
     assert len(packages) == 3
-    assert packages[0].identifier == "B==0.1.0"
-    assert packages[1].identifier == "C[V3]==1.0.0"
+    assert packages[0].identifier == "C[V3]==1.0.0"
+    assert packages[1].identifier == "B==0.1.0"
     assert packages[2].identifier == "A==0.2.0"
 
-    # Check spied functions / methods
-    if _CHECK_SPIED_CALL:
-        assert spied_fetch_next_combination.call_count == 2
-        assert spied_compute_combination.call_count == 2
-        assert spied_fetch_distance_mapping.call_count == 10
-        assert spied_extract_combinations.call_count == 2
-        assert spied_resolve_conflicts.call_count == 2
-        assert spied_compute_distance_mapping.call_count == 4
-        assert spied_generate_variant_combinations.call_count == 1
-        assert spied_trim_unreachable_from_graph.call_count == 2
-        assert spied_trim_invalid_from_graph.call_count == 0
-        assert spied_updated_by_distance.call_count == 3
-        assert spied_extract_conflicting_nodes.call_count == 3
-        assert spied_combined_requirements.call_count == 3
-        assert spied_extract_conflicting_requirements.call_count == 0
-        assert spied_extract_ordered_packages.call_count == 1
 
-
-def test_scenario_11(
-    spied_fetch_next_combination,
-    spied_compute_combination,
-    spied_fetch_distance_mapping,
-    spied_extract_combinations,
-    spied_resolve_conflicts,
-    spied_compute_distance_mapping,
-    spied_generate_variant_combinations,
-    spied_trim_unreachable_from_graph,
-    spied_trim_invalid_from_graph,
-    spied_updated_by_distance,
-    spied_extract_conflicting_nodes,
-    spied_combined_requirements,
-    spied_extract_conflicting_requirements,
-    spied_extract_ordered_packages
-):
+def test_scenario_11():
     """Compute packages for the following graph.
 
     When a definition variant is present more than other variants from the same
@@ -1324,40 +883,8 @@ def test_scenario_11(
     assert packages[1].identifier == "B==2.0.0"
     assert packages[2].identifier == "A[V2]==1.0.0"
 
-    # Check spied functions / methods
-    if _CHECK_SPIED_CALL:
-        assert spied_fetch_next_combination.call_count == 1
-        assert spied_compute_combination.call_count == 1
-        assert spied_fetch_distance_mapping.call_count == 5
-        assert spied_extract_combinations.call_count == 1
-        assert spied_resolve_conflicts.call_count == 1
-        assert spied_compute_distance_mapping.call_count == 3
-        assert spied_generate_variant_combinations.call_count == 1
-        assert spied_trim_unreachable_from_graph.call_count == 1
-        assert spied_trim_invalid_from_graph.call_count == 1
-        assert spied_updated_by_distance.call_count == 0
-        assert spied_extract_conflicting_nodes.call_count == 0
-        assert spied_combined_requirements.call_count == 0
-        assert spied_extract_conflicting_requirements.call_count == 0
-        assert spied_extract_ordered_packages.call_count == 1
 
-
-def test_scenario_12(
-    spied_fetch_next_combination,
-    spied_compute_combination,
-    spied_fetch_distance_mapping,
-    spied_extract_combinations,
-    spied_resolve_conflicts,
-    spied_compute_distance_mapping,
-    spied_generate_variant_combinations,
-    spied_trim_unreachable_from_graph,
-    spied_trim_invalid_from_graph,
-    spied_updated_by_distance,
-    spied_extract_conflicting_nodes,
-    spied_combined_requirements,
-    spied_extract_conflicting_requirements,
-    spied_extract_ordered_packages
-):
+def test_scenario_12():
     """Compute packages for the following graph.
 
     When two versions of a definition are added to the graph with all their
@@ -1466,40 +993,8 @@ def test_scenario_12(
     assert packages[1].identifier == "B==3.0.0"
     assert packages[2].identifier == "A[V3]==0.5.0"
 
-    # Check spied functions / methods
-    if _CHECK_SPIED_CALL:
-        assert spied_fetch_next_combination.call_count == 1
-        assert spied_compute_combination.call_count == 1
-        assert spied_fetch_distance_mapping.call_count == 10
-        assert spied_extract_combinations.call_count == 1
-        assert spied_resolve_conflicts.call_count == 1
-        assert spied_compute_distance_mapping.call_count == 4
-        assert spied_generate_variant_combinations.call_count == 1
-        assert spied_trim_unreachable_from_graph.call_count == 2
-        assert spied_trim_invalid_from_graph.call_count == 1
-        assert spied_updated_by_distance.call_count == 2
-        assert spied_extract_conflicting_nodes.call_count == 2
-        assert spied_combined_requirements.call_count == 2
-        assert spied_extract_conflicting_requirements.call_count == 0
-        assert spied_extract_ordered_packages.call_count == 1
 
-
-def test_scenario_13(
-    spied_fetch_next_combination,
-    spied_compute_combination,
-    spied_fetch_distance_mapping,
-    spied_extract_combinations,
-    spied_resolve_conflicts,
-    spied_compute_distance_mapping,
-    spied_generate_variant_combinations,
-    spied_trim_unreachable_from_graph,
-    spied_trim_invalid_from_graph,
-    spied_updated_by_distance,
-    spied_extract_conflicting_nodes,
-    spied_combined_requirements,
-    spied_extract_conflicting_requirements,
-    spied_extract_ordered_packages
-):
+def test_scenario_13():
     """Compute packages for the following graph.
 
     When computing a graph combination, all variant nodes that should not be
@@ -1598,40 +1093,8 @@ def test_scenario_13(
     assert packages[1].identifier == "B==1.0.0"
     assert packages[2].identifier == "A[V1]==0.5.0"
 
-    # Check spied functions / methods
-    if _CHECK_SPIED_CALL:
-        assert spied_fetch_next_combination.call_count == 3
-        assert spied_compute_combination.call_count == 3
-        assert spied_fetch_distance_mapping.call_count == 18
-        assert spied_extract_combinations.call_count == 1
-        assert spied_resolve_conflicts.call_count == 3
-        assert spied_compute_distance_mapping.call_count == 8
-        assert spied_generate_variant_combinations.call_count == 1
-        assert spied_trim_unreachable_from_graph.call_count == 4
-        assert spied_trim_invalid_from_graph.call_count == 3
-        assert spied_updated_by_distance.call_count == 4
-        assert spied_extract_conflicting_nodes.call_count == 2
-        assert spied_combined_requirements.call_count == 2
-        assert spied_extract_conflicting_requirements.call_count == 0
-        assert spied_extract_ordered_packages.call_count == 1
 
-
-def test_scenario_14(
-    spied_fetch_next_combination,
-    spied_compute_combination,
-    spied_fetch_distance_mapping,
-    spied_extract_combinations,
-    spied_resolve_conflicts,
-    spied_compute_distance_mapping,
-    spied_generate_variant_combinations,
-    spied_trim_unreachable_from_graph,
-    spied_trim_invalid_from_graph,
-    spied_updated_by_distance,
-    spied_extract_conflicting_nodes,
-    spied_combined_requirements,
-    spied_extract_conflicting_requirements,
-    spied_extract_ordered_packages
-):
+def test_scenario_14():
     """Compute packages for the following graph.
 
     When several packages with variants are added to the graph, the variant
@@ -1722,40 +1185,8 @@ def test_scenario_14(
     assert packages[1].identifier == "B[V4]"
     assert packages[2].identifier == "A[V3]"
 
-    # Check spied functions / methods
-    if _CHECK_SPIED_CALL:
-        assert spied_fetch_next_combination.call_count == 1
-        assert spied_compute_combination.call_count == 1
-        assert spied_fetch_distance_mapping.call_count == 4
-        assert spied_extract_combinations.call_count == 1
-        assert spied_resolve_conflicts.call_count == 1
-        assert spied_compute_distance_mapping.call_count == 2
-        assert spied_generate_variant_combinations.call_count == 1
-        assert spied_trim_unreachable_from_graph.call_count == 1
-        assert spied_trim_invalid_from_graph.call_count == 0
-        assert spied_updated_by_distance.call_count == 0
-        assert spied_extract_conflicting_nodes.call_count == 0
-        assert spied_combined_requirements.call_count == 0
-        assert spied_extract_conflicting_requirements.call_count == 0
-        assert spied_extract_ordered_packages.call_count == 1
 
-
-def test_scenario_15(
-    spied_fetch_next_combination,
-    spied_compute_combination,
-    spied_fetch_distance_mapping,
-    spied_extract_combinations,
-    spied_resolve_conflicts,
-    spied_compute_distance_mapping,
-    spied_generate_variant_combinations,
-    spied_trim_unreachable_from_graph,
-    spied_trim_invalid_from_graph,
-    spied_updated_by_distance,
-    spied_extract_conflicting_nodes,
-    spied_combined_requirements,
-    spied_extract_conflicting_requirements,
-    spied_extract_ordered_packages
-):
+def test_scenario_15():
     """Compute packages for the following graph.
 
     If a definition variant contains an error, the graph combinations list will
@@ -1849,40 +1280,8 @@ def test_scenario_15(
     assert packages[1].identifier == "B[V4]"
     assert packages[2].identifier == "A[V2]"
 
-    # Check spied functions / methods
-    if _CHECK_SPIED_CALL:
-        assert spied_fetch_next_combination.call_count == 9
-        assert spied_compute_combination.call_count == 9
-        assert spied_fetch_distance_mapping.call_count == 28
-        assert spied_extract_combinations.call_count == 1
-        assert spied_resolve_conflicts.call_count == 9
-        assert spied_compute_distance_mapping.call_count == 10
-        assert spied_generate_variant_combinations.call_count == 1
-        assert spied_trim_unreachable_from_graph.call_count == 9
-        assert spied_trim_invalid_from_graph.call_count == 0
-        assert spied_updated_by_distance.call_count == 8
-        assert spied_extract_conflicting_nodes.call_count == 0
-        assert spied_combined_requirements.call_count == 0
-        assert spied_extract_conflicting_requirements.call_count == 0
-        assert spied_extract_ordered_packages.call_count == 1
 
-
-def test_scenario_16(
-    spied_fetch_next_combination,
-    spied_compute_combination,
-    spied_fetch_distance_mapping,
-    spied_extract_combinations,
-    spied_resolve_conflicts,
-    spied_compute_distance_mapping,
-    spied_generate_variant_combinations,
-    spied_trim_unreachable_from_graph,
-    spied_trim_invalid_from_graph,
-    spied_updated_by_distance,
-    spied_extract_conflicting_nodes,
-    spied_combined_requirements,
-    spied_extract_conflicting_requirements,
-    spied_extract_ordered_packages
-):
+def test_scenario_16():
     """Compute packages for the following graph.
 
     For the same example as scenario 15, if the package 'A[V3]' has a
@@ -1989,40 +1388,8 @@ def test_scenario_16(
     assert packages[2].identifier == "B[V4]"
     assert packages[3].identifier == "A[V2]"
 
-    # Check spied functions / methods
-    if _CHECK_SPIED_CALL:
-        assert spied_fetch_next_combination.call_count == 9
-        assert spied_compute_combination.call_count == 9
-        assert spied_fetch_distance_mapping.call_count == 22
-        assert spied_extract_combinations.call_count == 1
-        assert spied_resolve_conflicts.call_count == 2
-        assert spied_compute_distance_mapping.call_count == 11
-        assert spied_generate_variant_combinations.call_count == 1
-        assert spied_trim_unreachable_from_graph.call_count == 9
-        assert spied_trim_invalid_from_graph.call_count == 1
-        assert spied_updated_by_distance.call_count == 1
-        assert spied_extract_conflicting_nodes.call_count == 1
-        assert spied_combined_requirements.call_count == 1
-        assert spied_extract_conflicting_requirements.call_count == 1
-        assert spied_extract_ordered_packages.call_count == 1
 
-
-def test_scenario_17(
-    spied_fetch_next_combination,
-    spied_compute_combination,
-    spied_fetch_distance_mapping,
-    spied_extract_combinations,
-    spied_resolve_conflicts,
-    spied_compute_distance_mapping,
-    spied_generate_variant_combinations,
-    spied_trim_unreachable_from_graph,
-    spied_trim_invalid_from_graph,
-    spied_updated_by_distance,
-    spied_extract_conflicting_nodes,
-    spied_combined_requirements,
-    spied_extract_conflicting_requirements,
-    spied_extract_ordered_packages
-):
+def test_scenario_17():
     """Compute packages for the following graph.
 
     When a package has a condition which is not fulfilled, it is not included
@@ -2074,40 +1441,8 @@ def test_scenario_17(
     assert len(packages) == 1
     assert packages[0].identifier == "A==1.1.0"
 
-    # Check spied functions / methods
-    if _CHECK_SPIED_CALL:
-        assert spied_fetch_next_combination.call_count == 1
-        assert spied_compute_combination.call_count == 1
-        assert spied_fetch_distance_mapping.call_count == 1
-        assert spied_extract_combinations.call_count == 1
-        assert spied_resolve_conflicts.call_count == 1
-        assert spied_compute_distance_mapping.call_count == 1
-        assert spied_generate_variant_combinations.call_count == 0
-        assert spied_trim_unreachable_from_graph.call_count == 0
-        assert spied_trim_invalid_from_graph.call_count == 0
-        assert spied_updated_by_distance.call_count == 0
-        assert spied_extract_conflicting_nodes.call_count == 0
-        assert spied_combined_requirements.call_count == 0
-        assert spied_extract_conflicting_requirements.call_count == 0
-        assert spied_extract_ordered_packages.call_count == 1
 
-
-def test_scenario_18(
-    spied_fetch_next_combination,
-    spied_compute_combination,
-    spied_fetch_distance_mapping,
-    spied_extract_combinations,
-    spied_resolve_conflicts,
-    spied_compute_distance_mapping,
-    spied_generate_variant_combinations,
-    spied_trim_unreachable_from_graph,
-    spied_trim_invalid_from_graph,
-    spied_updated_by_distance,
-    spied_extract_conflicting_nodes,
-    spied_combined_requirements,
-    spied_extract_conflicting_requirements,
-    spied_extract_ordered_packages
-):
+def test_scenario_18():
     """Compute packages for the following graph.
 
     When a package has a condition which is fulfilled, it is properly included
@@ -2162,40 +1497,8 @@ def test_scenario_18(
     assert packages[1].identifier == "B==1.0.0"
     assert packages[2].identifier == "A==1.1.0"
 
-    # Check spied functions / methods
-    if _CHECK_SPIED_CALL:
-        assert spied_fetch_next_combination.call_count == 1
-        assert spied_compute_combination.call_count == 1
-        assert spied_fetch_distance_mapping.call_count == 1
-        assert spied_extract_combinations.call_count == 1
-        assert spied_resolve_conflicts.call_count == 1
-        assert spied_compute_distance_mapping.call_count == 1
-        assert spied_generate_variant_combinations.call_count == 0
-        assert spied_trim_unreachable_from_graph.call_count == 0
-        assert spied_trim_invalid_from_graph.call_count == 0
-        assert spied_updated_by_distance.call_count == 0
-        assert spied_extract_conflicting_nodes.call_count == 0
-        assert spied_combined_requirements.call_count == 0
-        assert spied_extract_conflicting_requirements.call_count == 0
-        assert spied_extract_ordered_packages.call_count == 1
 
-
-def test_scenario_19(
-    spied_fetch_next_combination,
-    spied_compute_combination,
-    spied_fetch_distance_mapping,
-    spied_extract_combinations,
-    spied_resolve_conflicts,
-    spied_compute_distance_mapping,
-    spied_generate_variant_combinations,
-    spied_trim_unreachable_from_graph,
-    spied_trim_invalid_from_graph,
-    spied_updated_by_distance,
-    spied_extract_conflicting_nodes,
-    spied_combined_requirements,
-    spied_extract_conflicting_requirements,
-    spied_extract_ordered_packages
-):
+def test_scenario_19():
     """Compute packages for the following graph.
 
     A package condition can be fulfilled by packages deep in the graph.
@@ -2214,10 +1517,7 @@ def test_scenario_19(
                  |
                  `--(E>=2): E==2.3.0
 
-    Expected: E==2.3.0, D==0.1.4, B==0.1.0, C==0.3.2, G==2.0.2, A==0.2.0
-
-    The position of 'C==0.3.2' / 'G==2.0.2' can vary as they have similar
-    priority numbers.
+    Expected: E==2.3.0, D==0.1.4, B==0.1.0, G==2.0.2, C==0.3.2, A==0.2.0
 
     """
     definition_mapping = {
@@ -2273,48 +1573,12 @@ def test_scenario_19(
     assert packages[0].identifier == "E==2.3.0"
     assert packages[1].identifier == "D==0.1.4"
     assert packages[2].identifier == "B==0.1.0"
-
-    # Order can vary cause both have priority of 2
-    assert packages[3].identifier in ["C==0.3.2", "G==2.0.2"]
-    assert packages[4].identifier in ["C==0.3.2", "G==2.0.2"]
-    assert packages[4] != packages[3]
-
+    assert packages[3].identifier == "G==2.0.2"
+    assert packages[4].identifier == "C==0.3.2"
     assert packages[5].identifier == "A==0.2.0"
 
-    # Check spied functions / methods
-    if _CHECK_SPIED_CALL:
-        assert spied_fetch_next_combination.call_count == 1
-        assert spied_compute_combination.call_count == 1
-        assert spied_fetch_distance_mapping.call_count == 1
-        assert spied_extract_combinations.call_count == 1
-        assert spied_resolve_conflicts.call_count == 1
-        assert spied_compute_distance_mapping.call_count == 1
-        assert spied_generate_variant_combinations.call_count == 0
-        assert spied_trim_unreachable_from_graph.call_count == 0
-        assert spied_trim_invalid_from_graph.call_count == 0
-        assert spied_updated_by_distance.call_count == 0
-        assert spied_extract_conflicting_nodes.call_count == 0
-        assert spied_combined_requirements.call_count == 0
-        assert spied_extract_conflicting_requirements.call_count == 0
-        assert spied_extract_ordered_packages.call_count == 1
 
-
-def test_scenario_20(
-    spied_fetch_next_combination,
-    spied_compute_combination,
-    spied_fetch_distance_mapping,
-    spied_extract_combinations,
-    spied_resolve_conflicts,
-    spied_compute_distance_mapping,
-    spied_generate_variant_combinations,
-    spied_trim_unreachable_from_graph,
-    spied_trim_invalid_from_graph,
-    spied_updated_by_distance,
-    spied_extract_conflicting_nodes,
-    spied_combined_requirements,
-    spied_extract_conflicting_requirements,
-    spied_extract_ordered_packages
-):
+def test_scenario_20():
     """Compute packages for the following graph.
 
     For the same example as the scenario 19, if the condition can not be
@@ -2398,40 +1662,8 @@ def test_scenario_20(
     assert packages[2].identifier == "B==0.1.0"
     assert packages[3].identifier == "G==2.0.2"
 
-    # Check spied functions / methods
-    if _CHECK_SPIED_CALL:
-        assert spied_fetch_next_combination.call_count == 1
-        assert spied_compute_combination.call_count == 1
-        assert spied_fetch_distance_mapping.call_count == 1
-        assert spied_extract_combinations.call_count == 1
-        assert spied_resolve_conflicts.call_count == 1
-        assert spied_compute_distance_mapping.call_count == 1
-        assert spied_generate_variant_combinations.call_count == 0
-        assert spied_trim_unreachable_from_graph.call_count == 0
-        assert spied_trim_invalid_from_graph.call_count == 0
-        assert spied_updated_by_distance.call_count == 0
-        assert spied_extract_conflicting_nodes.call_count == 0
-        assert spied_combined_requirements.call_count == 0
-        assert spied_extract_conflicting_requirements.call_count == 0
-        assert spied_extract_ordered_packages.call_count == 1
 
-
-def test_scenario_21(
-    spied_fetch_next_combination,
-    spied_compute_combination,
-    spied_fetch_distance_mapping,
-    spied_extract_combinations,
-    spied_resolve_conflicts,
-    spied_compute_distance_mapping,
-    spied_generate_variant_combinations,
-    spied_trim_unreachable_from_graph,
-    spied_trim_invalid_from_graph,
-    spied_updated_by_distance,
-    spied_extract_conflicting_nodes,
-    spied_combined_requirements,
-    spied_extract_conflicting_requirements,
-    spied_extract_ordered_packages
-):
+def test_scenario_21():
     """Compute packages for the following graph.
 
     A package which has been added to the graph when its conditions were
@@ -2546,40 +1778,8 @@ def test_scenario_21(
     assert packages[2].identifier == "B==0.1.0"
     assert packages[3].identifier == "G==2.0.2"
 
-    # Check spied functions / methods
-    if _CHECK_SPIED_CALL:
-        assert spied_fetch_next_combination.call_count == 1
-        assert spied_compute_combination.call_count == 1
-        assert spied_fetch_distance_mapping.call_count == 8
-        assert spied_extract_combinations.call_count == 1
-        assert spied_resolve_conflicts.call_count == 1
-        assert spied_compute_distance_mapping.call_count == 5
-        assert spied_generate_variant_combinations.call_count == 0
-        assert spied_trim_unreachable_from_graph.call_count == 2
-        assert spied_trim_invalid_from_graph.call_count == 3
-        assert spied_updated_by_distance.call_count == 1
-        assert spied_extract_conflicting_nodes.call_count == 2
-        assert spied_combined_requirements.call_count == 1
-        assert spied_extract_conflicting_requirements.call_count == 0
-        assert spied_extract_ordered_packages.call_count == 1
 
-
-def test_scenario_22(
-    spied_fetch_next_combination,
-    spied_compute_combination,
-    spied_fetch_distance_mapping,
-    spied_extract_combinations,
-    spied_resolve_conflicts,
-    spied_compute_distance_mapping,
-    spied_generate_variant_combinations,
-    spied_trim_unreachable_from_graph,
-    spied_trim_invalid_from_graph,
-    spied_updated_by_distance,
-    spied_extract_conflicting_nodes,
-    spied_combined_requirements,
-    spied_extract_conflicting_requirements,
-    spied_extract_ordered_packages
-):
+def test_scenario_22():
     """Fail to compute packages for the following graph.
 
     Root
@@ -2621,40 +1821,8 @@ def test_scenario_22(
         "Namespace1, Namespace2]."
     ) in str(error.value)
 
-    # Check spied functions / methods
-    if _CHECK_SPIED_CALL:
-        assert spied_fetch_next_combination.call_count == 2
-        assert spied_compute_combination.call_count == 1
-        assert spied_fetch_distance_mapping.call_count == 1
-        assert spied_extract_combinations.call_count == 1
-        assert spied_resolve_conflicts.call_count == 1
-        assert spied_compute_distance_mapping.call_count == 1
-        assert spied_generate_variant_combinations.call_count == 0
-        assert spied_trim_unreachable_from_graph.call_count == 0
-        assert spied_trim_invalid_from_graph.call_count == 0
-        assert spied_updated_by_distance.call_count == 1
-        assert spied_extract_conflicting_nodes.call_count == 0
-        assert spied_combined_requirements.call_count == 0
-        assert spied_extract_conflicting_requirements.call_count == 0
-        assert spied_extract_ordered_packages.call_count == 0
 
-
-def test_scenario_23(
-    spied_fetch_next_combination,
-    spied_compute_combination,
-    spied_fetch_distance_mapping,
-    spied_extract_combinations,
-    spied_resolve_conflicts,
-    spied_compute_distance_mapping,
-    spied_generate_variant_combinations,
-    spied_trim_unreachable_from_graph,
-    spied_trim_invalid_from_graph,
-    spied_updated_by_distance,
-    spied_extract_conflicting_nodes,
-    spied_combined_requirements,
-    spied_extract_conflicting_requirements,
-    spied_extract_ordered_packages
-):
+def test_scenario_23():
     """Compute packages for the following graph.
 
     When a definition is found, its namespace is used to give hint when looking
@@ -2734,40 +1902,8 @@ def test_scenario_23(
     assert packages[2].identifier == "Namespace1::B==0.1.0"
     assert packages[3].identifier == "Namespace1::A"
 
-    # Check spied functions / methods
-    if _CHECK_SPIED_CALL:
-        assert spied_fetch_next_combination.call_count == 1
-        assert spied_compute_combination.call_count == 1
-        assert spied_fetch_distance_mapping.call_count == 1
-        assert spied_extract_combinations.call_count == 1
-        assert spied_resolve_conflicts.call_count == 1
-        assert spied_compute_distance_mapping.call_count == 1
-        assert spied_generate_variant_combinations.call_count == 0
-        assert spied_trim_unreachable_from_graph.call_count == 0
-        assert spied_trim_invalid_from_graph.call_count == 0
-        assert spied_updated_by_distance.call_count == 0
-        assert spied_extract_conflicting_nodes.call_count == 0
-        assert spied_combined_requirements.call_count == 0
-        assert spied_extract_conflicting_requirements.call_count == 0
-        assert spied_extract_ordered_packages.call_count == 1
 
-
-def test_scenario_24(
-    spied_fetch_next_combination,
-    spied_compute_combination,
-    spied_fetch_distance_mapping,
-    spied_extract_combinations,
-    spied_resolve_conflicts,
-    spied_compute_distance_mapping,
-    spied_generate_variant_combinations,
-    spied_trim_unreachable_from_graph,
-    spied_trim_invalid_from_graph,
-    spied_updated_by_distance,
-    spied_extract_conflicting_nodes,
-    spied_combined_requirements,
-    spied_extract_conflicting_requirements,
-    spied_extract_ordered_packages
-):
+def test_scenario_24():
     """Compute packages for the following graph.
 
     When a definition exists with and without a namespace, the one without a
@@ -2806,40 +1942,8 @@ def test_scenario_24(
     assert len(packages) == 1
     assert packages[0].identifier == "A==0.1.0"
 
-    # Check spied functions / methods
-    if _CHECK_SPIED_CALL:
-        assert spied_fetch_next_combination.call_count == 1
-        assert spied_compute_combination.call_count == 1
-        assert spied_fetch_distance_mapping.call_count == 1
-        assert spied_extract_combinations.call_count == 1
-        assert spied_resolve_conflicts.call_count == 1
-        assert spied_compute_distance_mapping.call_count == 1
-        assert spied_generate_variant_combinations.call_count == 0
-        assert spied_trim_unreachable_from_graph.call_count == 0
-        assert spied_trim_invalid_from_graph.call_count == 0
-        assert spied_updated_by_distance.call_count == 0
-        assert spied_extract_conflicting_nodes.call_count == 0
-        assert spied_combined_requirements.call_count == 0
-        assert spied_extract_conflicting_requirements.call_count == 0
-        assert spied_extract_ordered_packages.call_count == 1
 
-
-def test_scenario_25(
-    spied_fetch_next_combination,
-    spied_compute_combination,
-    spied_fetch_distance_mapping,
-    spied_extract_combinations,
-    spied_resolve_conflicts,
-    spied_compute_distance_mapping,
-    spied_generate_variant_combinations,
-    spied_trim_unreachable_from_graph,
-    spied_trim_invalid_from_graph,
-    spied_updated_by_distance,
-    spied_extract_conflicting_nodes,
-    spied_combined_requirements,
-    spied_extract_conflicting_requirements,
-    spied_extract_ordered_packages
-):
+def test_scenario_25():
     """Compute packages for the following graph.
 
     When a definition exists with and without a namespace, other definitions
@@ -2890,40 +1994,8 @@ def test_scenario_25(
     assert packages[0].identifier == "Namespace1::B==0.1.0"
     assert packages[1].identifier == "Namespace1::A==0.2.0"
 
-    # Check spied functions / methods
-    if _CHECK_SPIED_CALL:
-        assert spied_fetch_next_combination.call_count == 1
-        assert spied_compute_combination.call_count == 1
-        assert spied_fetch_distance_mapping.call_count == 1
-        assert spied_extract_combinations.call_count == 1
-        assert spied_resolve_conflicts.call_count == 1
-        assert spied_compute_distance_mapping.call_count == 1
-        assert spied_generate_variant_combinations.call_count == 0
-        assert spied_trim_unreachable_from_graph.call_count == 0
-        assert spied_trim_invalid_from_graph.call_count == 0
-        assert spied_updated_by_distance.call_count == 0
-        assert spied_extract_conflicting_nodes.call_count == 0
-        assert spied_combined_requirements.call_count == 0
-        assert spied_extract_conflicting_requirements.call_count == 0
-        assert spied_extract_ordered_packages.call_count == 1
 
-
-def test_scenario_26(
-    spied_fetch_next_combination,
-    spied_compute_combination,
-    spied_fetch_distance_mapping,
-    spied_extract_combinations,
-    spied_resolve_conflicts,
-    spied_compute_distance_mapping,
-    spied_generate_variant_combinations,
-    spied_trim_unreachable_from_graph,
-    spied_trim_invalid_from_graph,
-    spied_updated_by_distance,
-    spied_extract_conflicting_nodes,
-    spied_combined_requirements,
-    spied_extract_conflicting_requirements,
-    spied_extract_ordered_packages
-):
+def test_scenario_26():
     """Compute packages for the following graph.
 
     When a definition exists with and without a namespace, the one without a
@@ -2973,40 +2045,8 @@ def test_scenario_26(
     assert packages[0].identifier == "Namespace1::B==0.1.0"
     assert packages[1].identifier == "A==0.1.0"
 
-    # Check spied functions / methods
-    if _CHECK_SPIED_CALL:
-        assert spied_fetch_next_combination.call_count == 1
-        assert spied_compute_combination.call_count == 1
-        assert spied_fetch_distance_mapping.call_count == 1
-        assert spied_extract_combinations.call_count == 1
-        assert spied_resolve_conflicts.call_count == 1
-        assert spied_compute_distance_mapping.call_count == 1
-        assert spied_generate_variant_combinations.call_count == 0
-        assert spied_trim_unreachable_from_graph.call_count == 0
-        assert spied_trim_invalid_from_graph.call_count == 0
-        assert spied_updated_by_distance.call_count == 0
-        assert spied_extract_conflicting_nodes.call_count == 0
-        assert spied_combined_requirements.call_count == 0
-        assert spied_extract_conflicting_requirements.call_count == 0
-        assert spied_extract_ordered_packages.call_count == 1
 
-
-def test_scenario_27(
-    spied_fetch_next_combination,
-    spied_compute_combination,
-    spied_fetch_distance_mapping,
-    spied_extract_combinations,
-    spied_resolve_conflicts,
-    spied_compute_distance_mapping,
-    spied_generate_variant_combinations,
-    spied_trim_unreachable_from_graph,
-    spied_trim_invalid_from_graph,
-    spied_updated_by_distance,
-    spied_extract_conflicting_nodes,
-    spied_combined_requirements,
-    spied_extract_conflicting_requirements,
-    spied_extract_ordered_packages
-):
+def test_scenario_27():
     """Compute packages for the following graph.
 
     A package which has been added to the graph when its conditions were
@@ -3054,40 +2094,8 @@ def test_scenario_27(
     assert packages[0].identifier == "B==0.1.0"
     assert packages[1].identifier == "A==0.1.0"
 
-    # Check spied functions / methods
-    if _CHECK_SPIED_CALL:
-        assert spied_fetch_next_combination.call_count == 1
-        assert spied_compute_combination.call_count == 1
-        assert spied_fetch_distance_mapping.call_count == 6
-        assert spied_extract_combinations.call_count == 1
-        assert spied_resolve_conflicts.call_count == 1
-        assert spied_compute_distance_mapping.call_count == 2
-        assert spied_generate_variant_combinations.call_count == 0
-        assert spied_trim_unreachable_from_graph.call_count == 1
-        assert spied_trim_invalid_from_graph.call_count == 0
-        assert spied_updated_by_distance.call_count == 2
-        assert spied_extract_conflicting_nodes.call_count == 2
-        assert spied_combined_requirements.call_count == 2
-        assert spied_extract_conflicting_requirements.call_count == 0
-        assert spied_extract_ordered_packages.call_count == 1
 
-
-def test_scenario_28(
-    spied_fetch_next_combination,
-    spied_compute_combination,
-    spied_fetch_distance_mapping,
-    spied_extract_combinations,
-    spied_resolve_conflicts,
-    spied_compute_distance_mapping,
-    spied_generate_variant_combinations,
-    spied_trim_unreachable_from_graph,
-    spied_trim_invalid_from_graph,
-    spied_updated_by_distance,
-    spied_extract_conflicting_nodes,
-    spied_combined_requirements,
-    spied_extract_conflicting_requirements,
-    spied_extract_ordered_packages
-):
+def test_scenario_28():
     """Compute packages for the following graph.
 
     Like for the scenario 22, the package "A" has several namespaces available.
@@ -3128,40 +2136,8 @@ def test_scenario_28(
     assert len(packages) == 1
     assert packages[0].identifier == "A::A==0.2.0"
 
-    # Check spied functions / methods
-    if _CHECK_SPIED_CALL:
-        assert spied_fetch_next_combination.call_count == 1
-        assert spied_compute_combination.call_count == 1
-        assert spied_fetch_distance_mapping.call_count == 1
-        assert spied_extract_combinations.call_count == 1
-        assert spied_resolve_conflicts.call_count == 1
-        assert spied_compute_distance_mapping.call_count == 1
-        assert spied_generate_variant_combinations.call_count == 0
-        assert spied_trim_unreachable_from_graph.call_count == 0
-        assert spied_trim_invalid_from_graph.call_count == 0
-        assert spied_updated_by_distance.call_count == 0
-        assert spied_extract_conflicting_nodes.call_count == 0
-        assert spied_combined_requirements.call_count == 0
-        assert spied_extract_conflicting_requirements.call_count == 0
-        assert spied_extract_ordered_packages.call_count == 1
 
-
-def test_scenario_29(
-    spied_fetch_next_combination,
-    spied_compute_combination,
-    spied_fetch_distance_mapping,
-    spied_extract_combinations,
-    spied_resolve_conflicts,
-    spied_compute_distance_mapping,
-    spied_generate_variant_combinations,
-    spied_trim_unreachable_from_graph,
-    spied_trim_invalid_from_graph,
-    spied_updated_by_distance,
-    spied_extract_conflicting_nodes,
-    spied_combined_requirements,
-    spied_extract_conflicting_requirements,
-    spied_extract_ordered_packages
-):
+def test_scenario_29():
     """Compute packages for the following graph.
 
     Like for the scenario 7, the combined requirement of packages can lead to
@@ -3257,40 +2233,8 @@ def test_scenario_29(
     assert packages[1].identifier == "A[V1]==0.2.0"
     assert packages[2].identifier == "B==0.1.0"
 
-    # Check spied functions / methods
-    if _CHECK_SPIED_CALL:
-        assert spied_fetch_next_combination.call_count == 3
-        assert spied_compute_combination.call_count == 3
-        assert spied_fetch_distance_mapping.call_count == 10
-        assert spied_extract_combinations.call_count == 2
-        assert spied_resolve_conflicts.call_count == 2
-        assert spied_compute_distance_mapping.call_count == 5
-        assert spied_generate_variant_combinations.call_count == 2
-        assert spied_trim_unreachable_from_graph.call_count == 3
-        assert spied_trim_invalid_from_graph.call_count == 0
-        assert spied_updated_by_distance.call_count == 1
-        assert spied_extract_conflicting_nodes.call_count == 1
-        assert spied_combined_requirements.call_count == 1
-        assert spied_extract_conflicting_requirements.call_count == 0
-        assert spied_extract_ordered_packages.call_count == 1
 
-
-def test_scenario_30(
-    spied_fetch_next_combination,
-    spied_compute_combination,
-    spied_fetch_distance_mapping,
-    spied_extract_combinations,
-    spied_resolve_conflicts,
-    spied_compute_distance_mapping,
-    spied_generate_variant_combinations,
-    spied_trim_unreachable_from_graph,
-    spied_trim_invalid_from_graph,
-    spied_updated_by_distance,
-    spied_extract_conflicting_nodes,
-    spied_combined_requirements,
-    spied_extract_conflicting_requirements,
-    spied_extract_ordered_packages
-):
+def test_scenario_30():
     """Fail to compute packages for the following graph.
 
     If a definition contains an error, it will lead to the failure of the graph
@@ -3334,40 +2278,8 @@ def test_scenario_30(
         "  * A==0.1.0: The requirement 'incorrect' could not be resolved."
     ) in str(error.value)
 
-    # Check spied functions / methods
-    if _CHECK_SPIED_CALL:
-        assert spied_fetch_next_combination.call_count == 2
-        assert spied_compute_combination.call_count == 1
-        assert spied_fetch_distance_mapping.call_count == 1
-        assert spied_extract_combinations.call_count == 1
-        assert spied_resolve_conflicts.call_count == 1
-        assert spied_compute_distance_mapping.call_count == 1
-        assert spied_generate_variant_combinations.call_count == 0
-        assert spied_trim_unreachable_from_graph.call_count == 0
-        assert spied_trim_invalid_from_graph.call_count == 0
-        assert spied_updated_by_distance.call_count == 1
-        assert spied_extract_conflicting_nodes.call_count == 0
-        assert spied_combined_requirements.call_count == 0
-        assert spied_extract_conflicting_requirements.call_count == 0
-        assert spied_extract_ordered_packages.call_count == 0
 
-
-def test_scenario_31(
-    spied_fetch_next_combination,
-    spied_compute_combination,
-    spied_fetch_distance_mapping,
-    spied_extract_combinations,
-    spied_resolve_conflicts,
-    spied_compute_distance_mapping,
-    spied_generate_variant_combinations,
-    spied_trim_unreachable_from_graph,
-    spied_trim_invalid_from_graph,
-    spied_updated_by_distance,
-    spied_extract_conflicting_nodes,
-    spied_combined_requirements,
-    spied_extract_conflicting_requirements,
-    spied_extract_ordered_packages
-):
+def test_scenario_31():
     """Fail to compute packages for the following graph.
 
     Like scenario 15, when a definition variant contains an error, the next
@@ -3438,40 +2350,8 @@ def test_scenario_31(
         "  * C==0.1.0: The requirement 'incorrect' could not be resolved."
     ) in str(error.value)
 
-    # Check spied functions / methods
-    if _CHECK_SPIED_CALL:
-        assert spied_fetch_next_combination.call_count == 3
-        assert spied_compute_combination.call_count == 2
-        assert spied_fetch_distance_mapping.call_count == 7
-        assert spied_extract_combinations.call_count == 1
-        assert spied_resolve_conflicts.call_count == 2
-        assert spied_compute_distance_mapping.call_count == 3
-        assert spied_generate_variant_combinations.call_count == 1
-        assert spied_trim_unreachable_from_graph.call_count == 2
-        assert spied_trim_invalid_from_graph.call_count == 0
-        assert spied_updated_by_distance.call_count == 2
-        assert spied_extract_conflicting_nodes.call_count == 0
-        assert spied_combined_requirements.call_count == 0
-        assert spied_extract_conflicting_requirements.call_count == 0
-        assert spied_extract_ordered_packages.call_count == 0
 
-
-def test_scenario_32(
-    spied_fetch_next_combination,
-    spied_compute_combination,
-    spied_fetch_distance_mapping,
-    spied_extract_combinations,
-    spied_resolve_conflicts,
-    spied_compute_distance_mapping,
-    spied_generate_variant_combinations,
-    spied_trim_unreachable_from_graph,
-    spied_trim_invalid_from_graph,
-    spied_updated_by_distance,
-    spied_extract_conflicting_nodes,
-    spied_combined_requirements,
-    spied_extract_conflicting_requirements,
-    spied_extract_ordered_packages
-):
+def test_scenario_32():
     """Fail to compute packages for the following graph.
 
     When a conflict is detected, it is being stored to prevent resolving a
@@ -3543,44 +2423,12 @@ def test_scenario_32(
     assert (
         "The dependency graph could not be resolved due to the "
         "following requirement conflicts:\n"
-        "  * B >1 \t[root]\n"
-        "  * B <1 \t[C==0.1.0]"
+        "  * ::B >1 \t[root]\n"
+        "  * ::B <1 \t[C==0.1.0]"
     ) in str(error.value)
 
-    # Check spied functions / methods
-    if _CHECK_SPIED_CALL:
-        assert spied_fetch_next_combination.call_count == 3
-        assert spied_compute_combination.call_count == 2
-        assert spied_fetch_distance_mapping.call_count == 6
-        assert spied_extract_combinations.call_count == 1
-        assert spied_resolve_conflicts.call_count == 1
-        assert spied_compute_distance_mapping.call_count == 3
-        assert spied_generate_variant_combinations.call_count == 1
-        assert spied_trim_unreachable_from_graph.call_count == 2
-        assert spied_trim_invalid_from_graph.call_count == 0
-        assert spied_updated_by_distance.call_count == 1
-        assert spied_extract_conflicting_nodes.call_count == 1
-        assert spied_combined_requirements.call_count == 2
-        assert spied_extract_conflicting_requirements.call_count == 1
-        assert spied_extract_ordered_packages.call_count == 0
 
-
-def test_scenario_33(
-    spied_fetch_next_combination,
-    spied_compute_combination,
-    spied_fetch_distance_mapping,
-    spied_extract_combinations,
-    spied_resolve_conflicts,
-    spied_compute_distance_mapping,
-    spied_generate_variant_combinations,
-    spied_trim_unreachable_from_graph,
-    spied_trim_invalid_from_graph,
-    spied_updated_by_distance,
-    spied_extract_conflicting_nodes,
-    spied_combined_requirements,
-    spied_extract_conflicting_requirements,
-    spied_extract_ordered_packages
-):
+def test_scenario_33():
     """Compute packages for the following graph.
 
     Like scenario 2, the graph resolution will fail with the all node versions
@@ -3609,9 +2457,6 @@ def test_scenario_33(
 
     Expected: F==1.0.0, E==2.3.0, D==0.1.4, B==0.1.0, G==2.0.2, C==0.3.0
     A==0.2.0
-
-    The position of 'C==0.3.0' / 'G==2.0.2' and 'F==1.0.0' / 'E==2.3.0' can
-    vary as they have similar priority numbers.
 
     """
     definition_mapping = {
@@ -3693,57 +2538,17 @@ def test_scenario_33(
     packages = resolver.compute_packages([Requirement("A"), Requirement("G")])
 
     assert len(packages) == 7
-
-    # Order can vary cause both have priority of 5
-    assert packages[0].identifier in ["F==1.0.0", "E==2.3.0"]
-    assert packages[1].identifier in ["F==1.0.0", "E==2.3.0"]
-    assert packages[0] != packages[1]
-
+    assert packages[0].identifier == "F==1.0.0"
+    assert packages[1].identifier == "E==2.3.0"
     assert packages[2].identifier == "D==0.1.4"
-
-    # Order can vary cause both have priority of 2
-    assert packages[3].identifier in ["G==2.0.2", "B==0.1.0"]
-    assert packages[4].identifier in ["G==2.0.2", "B==0.1.0"]
-    assert packages[3] != packages[4]
-
+    assert packages[3].identifier == "B==0.1.0"
+    assert packages[4].identifier == "G==2.0.2"
     assert packages[5].identifier == "C==0.3.0"
     assert packages[6].identifier == "A==0.2.0"
 
-    # Check spied functions / methods
-    if _CHECK_SPIED_CALL:
-        assert spied_fetch_next_combination.call_count == 2
-        assert spied_compute_combination.call_count == 2
-        assert spied_fetch_distance_mapping.call_count == 4
-        assert spied_extract_combinations.call_count == 2
-        assert spied_resolve_conflicts.call_count == 2
-        assert spied_compute_distance_mapping.call_count == 2
-        assert spied_generate_variant_combinations.call_count == 0
-        assert spied_trim_unreachable_from_graph.call_count == 0
-        assert spied_trim_invalid_from_graph.call_count == 0
-        assert spied_updated_by_distance.call_count == 2
-        assert spied_extract_conflicting_nodes.call_count == 2
-        assert spied_combined_requirements.call_count == 4
-        assert spied_extract_conflicting_requirements.call_count == 1
-        assert spied_extract_ordered_packages.call_count == 1
 
-
-def test_scenario_34(
-    spied_fetch_next_combination,
-    spied_compute_combination,
-    spied_fetch_distance_mapping,
-    spied_extract_combinations,
-    spied_resolve_conflicts,
-    spied_compute_distance_mapping,
-    spied_generate_variant_combinations,
-    spied_trim_unreachable_from_graph,
-    spied_trim_invalid_from_graph,
-    spied_updated_by_distance,
-    spied_extract_conflicting_nodes,
-    spied_combined_requirements,
-    spied_extract_conflicting_requirements,
-    spied_extract_ordered_packages
-):
-    """Compute packages for the following graph.
+def test_scenario_34():
+    """Fail to compute packages for the following graph.
 
     Like scenario 13, parents are relinked when computing a graph combination
     to ensure that all requirements are still respected.
@@ -3789,6 +2594,10 @@ def test_scenario_34(
                 "identifier": "B",
                 "version": "3.0.0"
             }),
+            "2.0.0": wiz.definition.Definition({
+                "identifier": "B",
+                "version": "2.0.0"
+            }),
         },
         "C": {
             "-": wiz.definition.Definition({
@@ -3806,45 +2615,13 @@ def test_scenario_34(
     assert (
         "The dependency graph could not be resolved due to the following "
         "error(s):\n"
-        "  * root: Requirement 'A[V3]' can not be satisfied once "
+        "  * root: Requirement '::A[V3]' can not be satisfied once "
         "'A[V3]==1.0.0' is removed from the graph."
     ) in str(error.value)
 
-    # Check spied functions / methods
-    if _CHECK_SPIED_CALL:
-        assert spied_fetch_next_combination.call_count == 3
-        assert spied_compute_combination.call_count == 2
-        assert spied_fetch_distance_mapping.call_count == 8
-        assert spied_extract_combinations.call_count == 1
-        assert spied_resolve_conflicts.call_count == 2
-        assert spied_compute_distance_mapping.call_count == 4
-        assert spied_generate_variant_combinations.call_count == 1
-        assert spied_trim_unreachable_from_graph.call_count == 2
-        assert spied_trim_invalid_from_graph.call_count == 1
-        assert spied_updated_by_distance.call_count == 2
-        assert spied_extract_conflicting_nodes.call_count == 0
-        assert spied_combined_requirements.call_count == 0
-        assert spied_extract_conflicting_requirements.call_count == 0
-        assert spied_extract_ordered_packages.call_count == 0
 
-
-def test_scenario_35(
-    spied_fetch_next_combination,
-    spied_compute_combination,
-    spied_fetch_distance_mapping,
-    spied_extract_combinations,
-    spied_resolve_conflicts,
-    spied_compute_distance_mapping,
-    spied_generate_variant_combinations,
-    spied_trim_unreachable_from_graph,
-    spied_trim_invalid_from_graph,
-    spied_updated_by_distance,
-    spied_extract_conflicting_nodes,
-    spied_combined_requirements,
-    spied_extract_conflicting_requirements,
-    spied_extract_ordered_packages
-):
-    """Compute packages for the following graph.
+def test_scenario_35():
+    """Fail to compute packages for the following graph.
 
     Like scenario 34, two requirements are explicitly requesting conflicting
     variants: "A[V2]" and "A[V3]".
@@ -3937,23 +2714,184 @@ def test_scenario_35(
     assert (
         "The dependency graph could not be resolved due to the following "
         "error(s):\n"
-        "  * C: Requirement 'A[V2]' can not be satisfied once 'A[V2]==1.0.0' "
-        "is removed from the graph."
+        "  * C: Requirement '::A[V2]' can not be satisfied once 'A[V2]==1.0.0' "
+        "is removed from the graph.\n"
+        "  * D==0.1.0: Requirement '::A[V3]' can not be satisfied once "
+        "'A[V3]==1.0.0' is removed from the graph."
     ) in str(error.value)
 
-    # Check spied functions / methods
-    if _CHECK_SPIED_CALL:
-        assert spied_fetch_next_combination.call_count == 4
-        assert spied_compute_combination.call_count == 3
-        assert spied_fetch_distance_mapping.call_count == 13
-        assert spied_extract_combinations.call_count == 1
-        assert spied_resolve_conflicts.call_count == 3
-        assert spied_compute_distance_mapping.call_count == 7
-        assert spied_generate_variant_combinations.call_count == 1
-        assert spied_trim_unreachable_from_graph.call_count == 3
-        assert spied_trim_invalid_from_graph.call_count == 3
-        assert spied_updated_by_distance.call_count == 3
-        assert spied_extract_conflicting_nodes.call_count == 0
-        assert spied_combined_requirements.call_count == 0
-        assert spied_extract_conflicting_requirements.call_count == 0
-        assert spied_extract_ordered_packages.call_count == 0
+
+def test_scenario_36():
+    """Compute packages for the following graph.
+
+    When parents of conflicting nodes are themselves conflicting, we attempt to
+    resolve the conflicting parents before resolving the children. In this
+    case, one of the conflicting children disappears while resolving parent
+    conflicts.
+
+    Root
+     |
+     |--(A==1.2.*): A==1.2.0
+     |   |
+     |   `--(B<1): B==0.1.0
+     |
+     `--(B): B==1.2.3
+         |
+         `--(A==1.4.*): A==1.4.8
+
+    Expected: B==0.1.0, A==1.2.0
+
+    """
+    definition_mapping = {
+        "A": {
+            "1.4.8": wiz.definition.Definition({
+                "identifier": "A",
+                "version": "1.4.8"
+            }),
+            "1.2.0": wiz.definition.Definition({
+                "identifier": "A",
+                "version": "1.2.0",
+                "requirements": ["B<1"]
+            })
+        },
+        "B": {
+            "1.2.3": wiz.definition.Definition({
+                "identifier": "B",
+                "version": "1.2.3",
+                "requirements": ["A==1.4.*"]
+            }),
+            "0.1.0": wiz.definition.Definition({
+                "identifier": "B",
+                "version": "0.1.0",
+            })
+        },
+    }
+
+    resolver = wiz.graph.Resolver(definition_mapping)
+
+    packages = resolver.compute_packages([
+        Requirement("A==1.2.*"), Requirement("B")
+    ])
+
+    assert len(packages) == 2
+    assert packages[0].identifier == "B==0.1.0"
+    assert packages[1].identifier == "A==1.2.0"
+
+
+def test_scenario_37():
+    """Fail to compute packages for the following graph.
+
+    Like scenario 36, when parents of conflicting nodes are themselves
+    conflicting, we attempt to resolve the conflicting parents before resolving
+    the children. In this case, the parent conflicts does not remove the
+    children conflicts.
+
+    Root
+     |
+     |--(A==1.2.*): A==1.2.0
+     |   |
+     |   `--(B): B==1.2.3
+     |
+     `--(B<1): B==0.1.0
+         |
+         `--(A==1.4.*): A==1.4.8
+
+    Expected: Unable to compute due to requirement compatibility between
+    'A==1.4.*' and 'A==1.2.* '.
+
+    """
+    definition_mapping = {
+        "A": {
+            "1.4.8": wiz.definition.Definition({
+                "identifier": "A",
+                "version": "1.4.8"
+            }),
+            "1.2.0": wiz.definition.Definition({
+                "identifier": "A",
+                "version": "1.2.0",
+                "requirements": ["B"]
+            })
+        },
+        "B": {
+            "1.2.3": wiz.definition.Definition({
+                "identifier": "B",
+                "version": "1.2.3",
+            }),
+            "0.1.0": wiz.definition.Definition({
+                "identifier": "B",
+                "version": "0.1.0",
+                "requirements": ["A==1.4.*"]
+            })
+        },
+    }
+
+    resolver = wiz.graph.Resolver(definition_mapping)
+
+    with pytest.raises(wiz.exception.GraphResolutionError) as error:
+        resolver.compute_packages([Requirement("A==1.2.*"), Requirement("B<1")])
+
+    assert (
+        "The dependency graph could not be resolved due to the following "
+        "requirement conflicts:\n"
+        "  * ::A ==1.4.* \t[B==0.1.0]\n"
+        "  * ::A ==1.2.* \t[root]"
+    ) in str(error.value)
+
+
+def test_scenario_38():
+    """Fail to compute packages for the following graph.
+
+    Like scenario 37, when parents of conflicting nodes are themselves
+    conflicting, we attempt to resolve the conflicting parents before resolving
+    the children. In this case, the parent conflicts cannot be solved.
+
+    Root
+     |
+     |--(A==1.2.*): A==1.2.0
+     |   |
+     |   `--(B>1): B==1.2.3
+     |
+     `--(B<1): B==0.1.0
+         |
+         `--(A==1.4.*): A==1.4.8
+
+    Expected: Unable to compute due to requirement compatibility between
+    'A==1.4.*' and 'A==1.2.*'.
+
+    """
+    definition_mapping = {
+        "A": {
+            "1.4.8": wiz.definition.Definition({
+                "identifier": "A",
+                "version": "1.4.8"
+            }),
+            "1.2.0": wiz.definition.Definition({
+                "identifier": "A",
+                "version": "1.2.0",
+                "requirements": ["B>1"]
+            })
+        },
+        "B": {
+            "1.2.3": wiz.definition.Definition({
+                "identifier": "B",
+                "version": "1.2.3",
+            }),
+            "0.1.0": wiz.definition.Definition({
+                "identifier": "B",
+                "version": "0.1.0",
+                "requirements": ["A==1.4.*"]
+            })
+        },
+    }
+
+    resolver = wiz.graph.Resolver(definition_mapping)
+
+    with pytest.raises(wiz.exception.GraphResolutionError) as error:
+        resolver.compute_packages([Requirement("A==1.2.*"), Requirement("B<1")])
+
+    assert (
+        "The dependency graph could not be resolved due to the following "
+        "requirement conflicts:\n"
+        "  * ::A ==1.4.* \t[B==0.1.0]\n"
+        "  * ::A ==1.2.* \t[root]"
+    ) in str(error.value)

--- a/test/unit/test_command_line.py
+++ b/test/unit/test_command_line.py
@@ -1497,10 +1497,20 @@ def test_use_recorded(
         mocked_filesystem_export.assert_not_called()
 
 
+@pytest.mark.parametrize("options, max_combinations, max_attempts", [
+    ([], 10, 15),
+    (["-mc", "1"], 1, 15),
+    (["-ma", "1"], 10, 1),
+], ids=[
+    "simple",
+    "with-maximum-combinations",
+    "with-maximum-attempts",
+])
 def test_use_spawn_shell(
     mocked_system_query, mocked_registry_fetch, mocked_fetch_definition_mapping,
     mocked_resolve_context, mocked_resolve_command, mocked_spawn_execute,
-    mocked_spawn_shell, mocked_history_record_action, wiz_context, logger
+    mocked_spawn_shell, mocked_history_record_action, wiz_context, logger,
+    options, max_combinations, max_attempts
 ):
     """Use a resolved context."""
     mocked_system_query.return_value = "__SYSTEM__"
@@ -1509,10 +1519,10 @@ def test_use_spawn_shell(
     mocked_resolve_context.return_value = wiz_context
 
     runner = CliRunner()
-    result = runner.invoke(wiz.command_line.main, ["use", "foo"])
+    result = runner.invoke(wiz.command_line.main, ["use", "foo"] + options)
+    assert result.output == ""
     assert result.exit_code == 0
     assert not result.exception
-    assert result.output == ""
 
     mocked_fetch_definition_mapping.assert_called_once_with(
         ["/registry1", "/registry2"],
@@ -1520,7 +1530,11 @@ def test_use_spawn_shell(
     )
 
     mocked_resolve_context.assert_called_once_with(
-        ["foo"], "__MAPPING__", ignore_implicit=False, environ_mapping={},
+        ["foo"], "__MAPPING__",
+        ignore_implicit=False,
+        environ_mapping={},
+        maximum_combinations=max_combinations,
+        maximum_attempts=max_attempts,
     )
 
     mocked_spawn_shell.assert_called_once_with({
@@ -1537,10 +1551,20 @@ def test_use_spawn_shell(
     logger.error.assert_not_called()
 
 
+@pytest.mark.parametrize("options, max_combinations, max_attempts", [
+    ([], 10, 15),
+    (["-mc", "1"], 1, 15),
+    (["-ma", "1"], 10, 1),
+], ids=[
+    "simple",
+    "with-maximum-combinations",
+    "with-maximum-attempts",
+])
 def test_use_spawn_shell_view(
     mocked_system_query, mocked_registry_fetch, mocked_fetch_definition_mapping,
     mocked_resolve_context, mocked_resolve_command, mocked_spawn_execute,
-    mocked_spawn_shell, mocked_history_record_action, wiz_context, logger
+    mocked_spawn_shell, mocked_history_record_action, wiz_context, logger,
+    options, max_combinations, max_attempts
 ):
     """View a resolved context."""
     mocked_system_query.return_value = "__SYSTEM__"
@@ -1549,7 +1573,9 @@ def test_use_spawn_shell_view(
     mocked_resolve_context.return_value = wiz_context
 
     runner = CliRunner()
-    result = runner.invoke(wiz.command_line.main, ["use", "foo", "--view"])
+    result = runner.invoke(
+        wiz.command_line.main, ["use", "foo", "--view"] + options
+    )
     assert not result.exception
     assert result.exit_code == 0
     assert result.output == (
@@ -1585,7 +1611,11 @@ def test_use_spawn_shell_view(
     )
 
     mocked_resolve_context.assert_called_once_with(
-        ["foo"], "__MAPPING__", ignore_implicit=False, environ_mapping={},
+        ["foo"], "__MAPPING__",
+        ignore_implicit=False,
+        environ_mapping={},
+        maximum_combinations=max_combinations,
+        maximum_attempts=max_attempts,
     )
 
     mocked_spawn_shell.assert_not_called()
@@ -1595,10 +1625,20 @@ def test_use_spawn_shell_view(
     logger.error.assert_not_called()
 
 
+@pytest.mark.parametrize("options, max_combinations, max_attempts", [
+    ([], 10, 15),
+    (["-mc", "1"], 1, 15),
+    (["-ma", "1"], 10, 1),
+], ids=[
+    "simple",
+    "with-maximum-combinations",
+    "with-maximum-attempts",
+])
 def test_use_spawn_shell_view_empty(
     mocked_system_query, mocked_registry_fetch, mocked_fetch_definition_mapping,
     mocked_resolve_context, mocked_resolve_command, mocked_spawn_execute,
-    mocked_spawn_shell, mocked_history_record_action, logger
+    mocked_spawn_shell, mocked_history_record_action, logger,
+    options, max_combinations, max_attempts
 ):
     """View an empty resolved context."""
     mocked_system_query.return_value = "__SYSTEM__"
@@ -1612,7 +1652,9 @@ def test_use_spawn_shell_view_empty(
     }
 
     runner = CliRunner()
-    result = runner.invoke(wiz.command_line.main, ["use", "foo", "--view"])
+    result = runner.invoke(
+        wiz.command_line.main, ["use", "foo", "--view"] + options
+    )
     assert result.exit_code == 0
     assert not result.exception
     assert result.output == (
@@ -1645,7 +1687,11 @@ def test_use_spawn_shell_view_empty(
     )
 
     mocked_resolve_context.assert_called_once_with(
-        ["foo"], "__MAPPING__", ignore_implicit=False, environ_mapping={},
+        ["foo"], "__MAPPING__",
+        ignore_implicit=False,
+        environ_mapping={},
+        maximum_combinations=max_combinations,
+        maximum_attempts=max_attempts,
     )
 
     mocked_spawn_shell.assert_not_called()
@@ -1655,10 +1701,20 @@ def test_use_spawn_shell_view_empty(
     logger.error.assert_not_called()
 
 
+@pytest.mark.parametrize("options, max_combinations, max_attempts", [
+    ([], 10, 15),
+    (["-mc", "1"], 1, 15),
+    (["-ma", "1"], 10, 1),
+], ids=[
+    "simple",
+    "with-maximum-combinations",
+    "with-maximum-attempts",
+])
 def test_use_execute_command(
     mocked_system_query, mocked_registry_fetch, mocked_fetch_definition_mapping,
     mocked_resolve_context, mocked_resolve_command, mocked_spawn_execute,
-    mocked_spawn_shell, mocked_history_record_action, wiz_context, logger
+    mocked_spawn_shell, mocked_history_record_action, wiz_context, logger,
+    options, max_combinations, max_attempts
 ):
     """Execute a command within a resolved context."""
     mocked_system_query.return_value = "__SYSTEM__"
@@ -1670,7 +1726,9 @@ def test_use_execute_command(
     runner = CliRunner()
     result = runner.invoke(
         wiz.command_line.main,
-        ["use", "foo", "--", "fooExeDebug", "-t", "/path/to/script.foo"]
+        ["use", "foo"] + options + [
+            "--", "fooExeDebug", "-t", "/path/to/script.foo"
+        ]
     )
     assert result.exit_code == 0
     assert not result.exception
@@ -1682,7 +1740,11 @@ def test_use_execute_command(
     )
 
     mocked_resolve_context.assert_called_once_with(
-        ["foo"], "__MAPPING__", ignore_implicit=False, environ_mapping={},
+        ["foo"], "__MAPPING__",
+        ignore_implicit=False,
+        environ_mapping={},
+        maximum_combinations=max_combinations,
+        maximum_attempts=max_attempts,
     )
 
     mocked_resolve_command.assert_called_once_with(
@@ -1706,10 +1768,20 @@ def test_use_execute_command(
     logger.error.assert_not_called()
 
 
+@pytest.mark.parametrize("options, max_combinations, max_attempts", [
+    ([], 10, 15),
+    (["-mc", "1"], 1, 15),
+    (["-ma", "1"], 10, 1),
+], ids=[
+    "simple",
+    "with-maximum-combinations",
+    "with-maximum-attempts",
+])
 def test_use_with_resolution_error(
     mocked_system_query, mocked_registry_fetch, mocked_fetch_definition_mapping,
     mocked_resolve_context, mocked_resolve_command, mocked_spawn_execute,
-    mocked_spawn_shell, mocked_history_record_action, logger
+    mocked_spawn_shell, mocked_history_record_action, logger,
+    options, max_combinations, max_attempts
 ):
     """Fail to resolve a context."""
     exception = wiz.exception.WizError("Oh Shit!")
@@ -1719,7 +1791,9 @@ def test_use_with_resolution_error(
     mocked_resolve_context.side_effect = exception
 
     runner = CliRunner()
-    result = runner.invoke(wiz.command_line.main, ["use", "foo", "bim==0.1.*"])
+    result = runner.invoke(
+        wiz.command_line.main, ["use", "foo", "bim==0.1.*"] + options
+    )
     assert result.exit_code == 0
     assert not result.exception
     assert result.output == ""
@@ -1733,6 +1807,8 @@ def test_use_with_resolution_error(
         ["foo", "bim==0.1.*"], "__MAPPING__",
         ignore_implicit=False,
         environ_mapping={},
+        maximum_combinations=max_combinations,
+        maximum_attempts=max_attempts,
     )
 
     mocked_spawn_shell.assert_not_called()
@@ -1767,12 +1843,21 @@ def test_use_error(options):
     assert result.exception
 
 
+@pytest.mark.parametrize("options, max_combinations, max_attempts", [
+    ([], 10, 15),
+    (["-mc", "1"], 1, 15),
+    (["-ma", "1"], 10, 1),
+], ids=[
+    "simple",
+    "with-maximum-combinations",
+    "with-maximum-attempts",
+])
 def test_use_initial_environment(
     mocked_system_query, mocked_registry_fetch, mocked_fetch_definition_mapping,
     mocked_resolve_context, mocked_resolve_command, mocked_spawn_execute,
-    wiz_context
+    wiz_context, options, max_combinations, max_attempts
 ):
-    """Execurting a command to extend an initial environment."""
+    """Executing a command to extend an initial environment."""
     mocked_system_query.return_value = "__SYSTEM__"
     mocked_registry_fetch.return_value = ["/registry1", "/registry2"]
     mocked_fetch_definition_mapping.return_value = "__MAPPING__"
@@ -1781,10 +1866,11 @@ def test_use_initial_environment(
 
     runner = CliRunner()
     result = runner.invoke(
-        wiz.command_line.main, [
+        wiz.command_line.main,
+        [
             "--init", "PATH=/path", "--init", "PYTHONPATH=/other-path",
-            "use", "foo", "--", "fooExeDebug", "-t", "/path/to/script.foo"
-        ]
+            "use", "foo"
+        ] + options + ["--", "fooExeDebug", "-t", "/path/to/script.foo"]
     )
     assert result.exit_code == 0
     assert not result.exception
@@ -1793,6 +1879,8 @@ def test_use_initial_environment(
     mocked_resolve_context.assert_called_once_with(
         ["foo"], "__MAPPING__", ignore_implicit=False,
         environ_mapping={"PATH": "/path", "PYTHONPATH": "/other-path"},
+        maximum_combinations=max_combinations,
+        maximum_attempts=max_attempts,
     )
 
     mocked_spawn_execute.assert_called_once_with(
@@ -1844,11 +1932,20 @@ def test_run_recorded(
         mocked_filesystem_export.assert_not_called()
 
 
+@pytest.mark.parametrize("options, max_combinations, max_attempts", [
+    ([], 10, 15),
+    (["-mc", "1"], 1, 15),
+    (["-ma", "1"], 10, 1),
+], ids=[
+    "simple",
+    "with-maximum-combinations",
+    "with-maximum-attempts",
+])
 def test_run(
     mocked_system_query, mocked_registry_fetch, mocked_fetch_definition_mapping,
     mocked_fetch_package_request_from_command, mocked_resolve_context,
     mocked_resolve_command, mocked_spawn_execute, mocked_history_record_action,
-    wiz_context, logger
+    wiz_context, logger, options, max_combinations, max_attempts
 ):
     """Execute a command within a resolved context."""
     mocked_system_query.return_value = "__SYSTEM__"
@@ -1859,7 +1956,7 @@ def test_run(
     mocked_resolve_command.return_value = "__RESOLVED_COMMAND__"
 
     runner = CliRunner()
-    result = runner.invoke(wiz.command_line.main, ["run", "fooExe"])
+    result = runner.invoke(wiz.command_line.main, ["run", "fooExe"] + options)
     assert result.exit_code == 0
     assert not result.exception
     assert result.output == ""
@@ -1876,7 +1973,9 @@ def test_run(
     mocked_resolve_context.assert_called_once_with(
         ["__PACKAGE__"], "__MAPPING__",
         ignore_implicit=False,
-        environ_mapping={}
+        environ_mapping={},
+        maximum_combinations=max_combinations,
+        maximum_attempts=max_attempts,
     )
 
     mocked_resolve_command.assert_called_once_with(
@@ -1899,11 +1998,20 @@ def test_run(
     logger.error.assert_not_called()
 
 
+@pytest.mark.parametrize("options, max_combinations, max_attempts", [
+    ([], 10, 15),
+    (["-mc", "1"], 1, 15),
+    (["-ma", "1"], 10, 1),
+], ids=[
+    "simple",
+    "with-maximum-combinations",
+    "with-maximum-attempts",
+])
 def test_run_view(
     mocked_system_query, mocked_registry_fetch, mocked_fetch_definition_mapping,
     mocked_fetch_package_request_from_command, mocked_resolve_context,
     mocked_resolve_command, mocked_spawn_execute, mocked_history_record_action,
-    wiz_context, logger
+    wiz_context, logger, options, max_combinations, max_attempts
 ):
     """View a resolved context from a command execution."""
     mocked_system_query.return_value = "__SYSTEM__"
@@ -1914,7 +2022,9 @@ def test_run_view(
     mocked_resolve_command.return_value = "__RESOLVED_COMMAND__"
 
     runner = CliRunner()
-    result = runner.invoke(wiz.command_line.main, ["run", "fooExe", "--view"])
+    result = runner.invoke(
+        wiz.command_line.main, ["run", "fooExe", "--view"] + options
+    )
     assert not result.exception
     assert result.exit_code == 0
     assert result.output == (
@@ -1956,7 +2066,9 @@ def test_run_view(
     mocked_resolve_context.assert_called_once_with(
         ["__PACKAGE__"], "__MAPPING__",
         ignore_implicit=False,
-        environ_mapping={}
+        environ_mapping={},
+        maximum_combinations=max_combinations,
+        maximum_attempts=max_attempts,
     )
 
     mocked_resolve_command.assert_not_called()
@@ -1965,11 +2077,20 @@ def test_run_view(
     logger.error.assert_not_called()
 
 
+@pytest.mark.parametrize("options, max_combinations, max_attempts", [
+    ([], 10, 15),
+    (["-mc", "1"], 1, 15),
+    (["-ma", "1"], 10, 1),
+], ids=[
+    "simple",
+    "with-maximum-combinations",
+    "with-maximum-attempts",
+])
 def test_run_view_empty(
     mocked_system_query, mocked_registry_fetch, mocked_fetch_definition_mapping,
     mocked_fetch_package_request_from_command, mocked_resolve_context,
     mocked_resolve_command, mocked_spawn_execute, mocked_history_record_action,
-    logger
+    logger, options, max_combinations, max_attempts
 ):
     """View an empty resolved context from a command execution."""
     mocked_system_query.return_value = "__SYSTEM__"
@@ -1985,7 +2106,9 @@ def test_run_view_empty(
     mocked_resolve_command.return_value = "__RESOLVED_COMMAND__"
 
     runner = CliRunner()
-    result = runner.invoke(wiz.command_line.main, ["run", "fooExe", "--view"])
+    result = runner.invoke(
+        wiz.command_line.main, ["run", "fooExe", "--view"] + options
+    )
     assert result.exit_code == 0
     assert not result.exception
     assert result.output == (
@@ -2024,7 +2147,9 @@ def test_run_view_empty(
     mocked_resolve_context.assert_called_once_with(
         ["__PACKAGE__"], "__MAPPING__",
         ignore_implicit=False,
-        environ_mapping={}
+        environ_mapping={},
+        maximum_combinations=max_combinations,
+        maximum_attempts=max_attempts,
     )
 
     mocked_resolve_command.assert_not_called()
@@ -2033,11 +2158,20 @@ def test_run_view_empty(
     logger.error.assert_not_called()
 
 
+@pytest.mark.parametrize("options, max_combinations, max_attempts", [
+    ([], 10, 15),
+    (["-mc", "1"], 1, 15),
+    (["-ma", "1"], 10, 1),
+], ids=[
+    "simple",
+    "with-maximum-combinations",
+    "with-maximum-attempts",
+])
 def test_run_with_resolution_error(
     mocked_system_query, mocked_registry_fetch, mocked_fetch_definition_mapping,
     mocked_fetch_package_request_from_command, mocked_resolve_context,
     mocked_resolve_command, mocked_spawn_execute, mocked_history_record_action,
-    logger
+    logger, options, max_combinations, max_attempts
 ):
     """Fail to resolve a context."""
     exception = wiz.exception.WizError("Oh Shit!")
@@ -2048,7 +2182,7 @@ def test_run_with_resolution_error(
     mocked_resolve_context.side_effect = exception
 
     runner = CliRunner()
-    result = runner.invoke(wiz.command_line.main, ["run", "fooExe"])
+    result = runner.invoke(wiz.command_line.main, ["run", "fooExe"] + options)
     assert result.exit_code == 0
     assert not result.exception
     assert result.output == ""
@@ -2061,7 +2195,9 @@ def test_run_with_resolution_error(
     mocked_resolve_context.assert_called_once_with(
         ["__PACKAGE__"], "__MAPPING__",
         ignore_implicit=False,
-        environ_mapping={}
+        environ_mapping={},
+        maximum_combinations=max_combinations,
+        maximum_attempts=max_attempts,
     )
 
     mocked_fetch_package_request_from_command.assert_called_once_with(
@@ -2078,10 +2214,20 @@ def test_run_with_resolution_error(
     logger.error.assert_called_once_with("Oh Shit!")
 
 
+@pytest.mark.parametrize("options, max_combinations, max_attempts", [
+    ([], 10, 15),
+    (["-mc", "1"], 1, 15),
+    (["-ma", "1"], 10, 1),
+], ids=[
+    "simple",
+    "with-maximum-combinations",
+    "with-maximum-attempts",
+])
 def test_run_initial_environment(
     mocked_system_query, mocked_registry_fetch, mocked_fetch_definition_mapping,
     mocked_fetch_package_request_from_command, mocked_resolve_context,
-    mocked_resolve_command, mocked_spawn_execute, wiz_context
+    mocked_resolve_command, mocked_spawn_execute, wiz_context, options,
+    max_combinations, max_attempts
 ):
     """Execute a command to extend an initial environment."""
     mocked_system_query.return_value = "__SYSTEM__"
@@ -2096,7 +2242,8 @@ def test_run_initial_environment(
         wiz.command_line.main, [
             "--init", "PATH=/path", "--init", "PYTHONPATH=/other-path",
             "run", "fooExe"
-        ])
+        ] + options
+    )
     assert result.exit_code == 0
     assert not result.exception
     assert result.output == ""
@@ -2104,6 +2251,8 @@ def test_run_initial_environment(
     mocked_resolve_context.assert_called_once_with(
         ["__PACKAGE__"], "__MAPPING__", ignore_implicit=False,
         environ_mapping={"PATH": "/path", "PYTHONPATH": "/other-path"},
+        maximum_combinations=max_combinations,
+        maximum_attempts=max_attempts,
     )
 
     mocked_spawn_execute.assert_called_once_with(

--- a/test/unit/test_command_line.py
+++ b/test/unit/test_command_line.py
@@ -2580,7 +2580,12 @@ def test_install_overwrite_existing(
     mocked_system_query.return_value = "__SYSTEM__"
     mocked_registry_fetch.return_value = ["/registry1", "/registry2"]
     mocked_registry_install_to_path.side_effect = (
-        wiz.exception.DefinitionsExist(["foo [0.1.0]"]),
+        wiz.exception.DefinitionsExist([
+            wiz.definition.Definition({
+                "identifier": "foo",
+                "version": "0.1.0"
+            })
+        ]),
         None
     )
     mocked_click_confirm.return_value = True
@@ -2609,7 +2614,7 @@ def test_install_overwrite_existing(
 
     mocked_click_confirm.assert_called_once_with(
         "1 definition(s) already exist in registry.\n"
-        "- foo [0.1.0]\n"
+        "- 'foo' [0.1.0]\n"
         "Overwrite?"
     )
 
@@ -2627,7 +2632,12 @@ def test_install_skip_existing(
     mocked_system_query.return_value = "__SYSTEM__"
     mocked_registry_fetch.return_value = ["/registry1", "/registry2"]
     mocked_registry_install_to_path.side_effect = (
-        wiz.exception.DefinitionsExist(["foo [0.1.0]"]),
+        wiz.exception.DefinitionsExist([
+            wiz.definition.Definition({
+                "identifier": "foo",
+                "version": "0.1.0"
+            })
+        ]),
     )
     mocked_click_confirm.return_value = False
 
@@ -2649,7 +2659,7 @@ def test_install_skip_existing(
 
     mocked_click_confirm.assert_called_once_with(
         "1 definition(s) already exist in registry.\n"
-        "- foo [0.1.0]\n"
+        "- 'foo' [0.1.0]\n"
         "Overwrite?"
     )
 
@@ -2821,7 +2831,9 @@ def test_edit(
         "{\"identifier\": \"foo\",\"version\": \"0.1.0\"}"
     )
     mocked_click_confirm.return_value = True
-    mocked_filesystem_export.side_effect = [wiz.exception.FileExists(), None]
+    mocked_filesystem_export.side_effect = [
+        wiz.exception.FileExists("/path"), None
+    ]
 
     runner = CliRunner()
     result = runner.invoke(wiz.command_line.main, ["edit", "/path/to/foo.json"])
@@ -2985,7 +2997,7 @@ def test_edit_skip_existing(
     )
 
     mocked_click_confirm.return_value = False
-    mocked_filesystem_export.side_effect = wiz.exception.FileExists()
+    mocked_filesystem_export.side_effect = wiz.exception.FileExists("/path")
 
     runner = CliRunner()
     result = runner.invoke(

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -73,6 +73,10 @@ def test_fetch():
             "initial": {},
             "passthrough": []
         },
+        "resolver": {
+            "maximum_combinations": 10,
+            "maximum_attempts": 15,
+        },
         "command": {
             "max_content_width": 90,
             "verbosity": "info",
@@ -132,6 +136,10 @@ def test_fetch_with_personal():
                 "ENVIRON_TEST1": "VALUE"
             },
             "passthrough": []
+        },
+        "resolver": {
+            "maximum_combinations": 10,
+            "maximum_attempts": 15,
         },
         "command": {
             "max_content_width": 90,

--- a/test/unit/test_definition.py
+++ b/test/unit/test_definition.py
@@ -491,6 +491,14 @@ def test_query_definition_guess_default_namespace_counter():
         package_mapping["namespace1::foo"]["0.1.0"]
     )
 
+    assert (
+        wiz.definition.query(
+            requirement, package_mapping,
+            namespace_counter=Counter(["namespace1"])
+        ) ==
+        package_mapping["namespace1::foo"]["0.1.0"]
+    )
+
     # Counter with "namespace1" and "namespace2"
     with pytest.raises(wiz.exception.RequestNotFound) as error:
         wiz.definition.query(

--- a/test/unit/test_definition.py
+++ b/test/unit/test_definition.py
@@ -964,7 +964,7 @@ def test_discover_without_disabled(mocked_load, registries, definitions):
     ValueError,
     TypeError,
     wiz.exception.WizError,
-    wiz.exception.IncorrectDefinition
+    wiz.exception.DefinitionError
 ], ids=[
     "io-error",
     "value-error",
@@ -2023,12 +2023,10 @@ def test_definition_with_error():
     """Fail to create a definition with error."""
     data = {}
 
-    with pytest.raises(wiz.exception.IncorrectDefinition) as error:
+    with pytest.raises(wiz.exception.DefinitionError) as error:
         wiz.definition.Definition(data)
 
-    assert (
-        "IncorrectDefinition: 'identifier' is required."
-    ) in str(error)
+    assert "'identifier' is required." in str(error)
 
 
 def test_definition_with_version_error():
@@ -2038,12 +2036,10 @@ def test_definition_with_version_error():
         "version": "!!!"
     }
 
-    with pytest.raises(wiz.exception.IncorrectDefinition) as error:
+    with pytest.raises(wiz.exception.DefinitionError) as error:
         wiz.definition.Definition(data)
 
-    assert (
-        "IncorrectDefinition: Invalid version: '!!!'"
-    ) in str(error)
+    assert "Invalid version: '!!!'" in str(error)
 
 
 def test_definition_with_requirement_error():
@@ -2057,12 +2053,10 @@ def test_definition_with_requirement_error():
 
     definition = wiz.definition.Definition(data)
 
-    with pytest.raises(wiz.exception.InvalidRequirement) as error:
+    with pytest.raises(wiz.exception.RequirementError) as error:
         print(definition.requirements)
 
-    assert (
-        "InvalidRequirement: The requirement 'envA -!!!' is incorrect"
-    ) in str(error)
+    assert "The requirement 'envA -!!!' is incorrect" in str(error)
 
 
 def test_definition_with_condition_error():
@@ -2076,12 +2070,10 @@ def test_definition_with_condition_error():
 
     definition = wiz.definition.Definition(data)
 
-    with pytest.raises(wiz.exception.InvalidRequirement) as error:
+    with pytest.raises(wiz.exception.RequirementError) as error:
         print(definition.conditions)
 
-    assert (
-        "InvalidRequirement: The requirement 'envA -!!!' is incorrect"
-    ) in str(error)
+    assert "The requirement 'envA -!!!' is incorrect" in str(error)
 
 
 def test_definition_with_variant_requirement_error():
@@ -2100,12 +2092,10 @@ def test_definition_with_variant_requirement_error():
 
     definition = wiz.definition.Definition(data)
 
-    with pytest.raises(wiz.exception.InvalidRequirement) as error:
+    with pytest.raises(wiz.exception.RequirementError) as error:
         print(definition.variants[0].requirements)
 
-    assert (
-        "InvalidRequirement: The requirement 'envA -!!!' is incorrect"
-    ) in str(error)
+    assert "The requirement 'envA -!!!' is incorrect" in str(error)
 
 
 def test_definition_set():

--- a/test/unit/test_graph.py
+++ b/test/unit/test_graph.py
@@ -34,7 +34,7 @@ def mocked_graph(mocker):
 @pytest.fixture()
 def mocked_prune_graph(mocker):
     """Return mocked wiz.graph.VariantCombination.prune_graph method."""
-    return mocker.patch.object(wiz.graph.VariantCombination, "prune_graph")
+    return mocker.patch.object(wiz.graph.Combination, "prune_graph")
 
 
 @pytest.fixture()
@@ -2972,8 +2972,8 @@ def test_stored_node(mocker, options, weight):
 def test_combination(
     mocked_graph, mocked_deepcopy, mocked_prune_graph, options, copy_data
 ):
-    """Create a variant combination."""
-    combination = wiz.graph.VariantCombination(mocked_graph, **options)
+    """Create a graph combination."""
+    combination = wiz.graph.Combination(mocked_graph, **options)
 
     if copy_data:
         mocked_deepcopy.assert_called_once_with(mocked_graph)
@@ -3001,8 +3001,8 @@ def test_combination(
 def test_combination_with_removed_nodes(
     mocked_graph, mocked_deepcopy, mocked_prune_graph, options, copy_data
 ):
-    """Create a variant combination with node identifiers to remove."""
-    combination = wiz.graph.VariantCombination(
+    """Create a graph combination with node identifiers to remove."""
+    combination = wiz.graph.Combination(
         mocked_graph, nodes_to_remove={"foo[V2]", "foo[V1]", "bar[V1]"},
         **options
     )

--- a/test/unit/test_graph.py
+++ b/test/unit/test_graph.py
@@ -1,2060 +1,2539 @@
 # :coding: utf-8
 
+import collections
+import copy
+import itertools
+
 import pytest
-import types
-import re
 
-import six.moves
-
-from wiz.utility import Requirement, Version
 import wiz.graph
 import wiz.package
-import wiz.definition
-import wiz.exception
-
-
-@pytest.fixture()
-def mocked_queue(mocker):
-    """Return mocked Queue constructor."""
-    instance = mocker.Mock()
-    try:
-        import queue
-        mocker.patch("queue.Queue", return_value=instance)
-
-    except ImportError:
-        import Queue
-        mocker.patch("Queue.Queue", return_value=instance)
-
-    return instance
-
-
-@pytest.fixture()
-def mocked_graph(mocker):
-    """Return mocked Graph."""
-    graph = mocker.patch.object(wiz.graph, "Graph")
-    graph.ROOT = "root"
-    return graph
+from wiz.utility import Requirement
 
 
 @pytest.fixture()
 def mocked_resolver(mocker):
     """Return mocked Resolver."""
-    resolver = mocker.patch.object(wiz.graph, "Resolver")
-    return resolver
-
-
-@pytest.fixture()
-def mocked_graph_remove_node(mocker):
-    """Return mocked Graph.remove_node method."""
-    return mocker.patch.object(wiz.graph.Graph, "remove_node")
-
-
-@pytest.fixture()
-def mocked_updated_by_distance(mocker):
-    """Return mocked updated_by_distance method."""
-    return mocker.patch.object(wiz.graph, "updated_by_distance")
+    return mocker.Mock(definition_mapping={"__namespace__": {}})
 
 
 @pytest.fixture()
 def mocked_package_extract(mocker):
-    """Return mocked wiz.package.extract method."""
+    """Return mocked 'wiz.package.extract' function."""
     return mocker.patch.object(wiz.package, "extract")
 
 
-def test_resolver():
-    """Create a resolver."""
-    definition_mapping = {"defA": ["nodeA"], "defB": ["nodeB"]}
-    resolver = wiz.graph.Resolver(definition_mapping)
-    assert resolver.definition_mapping == definition_mapping
-    assert id(resolver.definition_mapping) == id(definition_mapping)
-
-
-@pytest.mark.parametrize("mapping, expected", [
-    (
-        {"root": []},
-        {"root": {"distance": 0, "parent": "root"}}
-    ),
-    (
-        {"root": ["A"], "A": []},
-        {
-            "root": {"distance": 0, "parent": "root"},
-            "A": {"distance": 1, "parent": "root"}
-        }
-    ),
-    (
-        {"root": ["A", "B"], "A": [], "B": []},
-        {
-            "root": {"distance": 0, "parent": "root"},
-            "A": {"distance": 1, "parent": "root"},
-            "B": {"distance": 2, "parent": "root"}
-        }
-    ),
-    (
-        {"root": ["A", "B", "C"], "A": [], "B": [], "C": []},
-        {
-            "root": {"distance": 0, "parent": "root"},
-            "A": {"distance": 1, "parent": "root"},
-            "B": {"distance": 2, "parent": "root"},
-            "C": {"distance": 3, "parent": "root"}
-        }
-    ),
-    (
-        {"root": ["A"], "A": ["B"], "B": []},
-        {
-            "root": {"distance": 0, "parent": "root"},
-            "A": {"distance": 1, "parent": "root"},
-            "B": {"distance": 2, "parent": "A"}
-        }
-    ),
-    (
-        {"root": ["A"], "A": ["B"], "B": ["C"], "C": []},
-        {
-            "root": {"distance": 0, "parent": "root"},
-            "A": {"distance": 1, "parent": "root"},
-            "B": {"distance": 2, "parent": "A"},
-            "C": {"distance": 3, "parent": "B"}
-        }
-    ),
-    (
-        {"root": ["A", "B"], "A": ["B"], "B": ["A"]},
-        {
-            "root": {"distance": 0, "parent": "root"},
-            "A": {"distance": 1, "parent": "root"},
-            "B": {"distance": 2, "parent": "root"}
-        }
-    ),
-    (
-        {
-            "root": ["A", "B"],
-            "A": ["C", "D"],
-            "B": ["D", "F", "G"],
-            "C": [],
-            "D": ["E"],
-            "E": [],
-            "F": [],
-            "G": []
-        },
-        {
-            "root": {"distance": 0, "parent": "root"},
-            "A": {"distance": 1, "parent": "root"},
-            "B": {"distance": 2, "parent": "root"},
-            "C": {"distance": 2, "parent": "A"},
-            "D": {"distance": 3, "parent": "A"},
-            "E": {"distance": 4, "parent": "D"},
-            "F": {"distance": 4, "parent": "B"},
-            "G": {"distance": 5, "parent": "B"},
-        }
-    ),
-    (
-        {
-            "root": ["A"],
-            "A": ["C", "E", "F"],
-            "B": ["F", "D"],
-            "C": [],
-            "D": [],
-            "E": [],
-            "F": []
-        },
-        {
-            "root": {"distance": 0, "parent": "root"},
-            "A": {"distance": 1, "parent": "root"},
-            "B": {"distance": None, "parent": None},
-            "C": {"distance": 2, "parent": "A"},
-            "D": {"distance": None, "parent": None},
-            "E": {"distance": 3, "parent": "A"},
-            "F": {"distance": 4, "parent": "A"},
-        }
-
-    ),
-    (
-        {
-            "root": ["A", "B", "F"],
-            "A": ["C", "D"],
-            "B": ["D", "F", "G"],
-            "C": ["G"],
-            "D": ["E"],
-            "E": ["A"],
-            "F": [],
-            "G": ["B"],
-        },
-        {
-            "root": {"distance": 0, "parent": "root"},
-            "A": {"distance": 1, "parent": "root"},
-            "B": {"distance": 2, "parent": "root"},
-            "C": {"distance": 2, "parent": "A"},
-            "D": {"distance": 3, "parent": "A"},
-            "E": {"distance": 4, "parent": "D"},
-            "F": {"distance": 3, "parent": "root"},
-            "G": {"distance": 3, "parent": "C"},
-        }
-    )
-], ids=[
-    "no-node",
-    "one-node",
-    "two-nodes",
-    "three-nodes",
-    "two-levels",
-    "three-levels",
-    "with-cycle",
-    "multi-levels",
-    "multi-levels-with-unreachable-nodes",
-    "complex-multi-levels"
-])
-def test_compute_distance_mapping(mocker, mocked_graph, mapping, expected):
-    """Compute distance mapping from Graph."""
-    nodes = [mocker.Mock(identifier=_id) for _id in mapping.keys()]
-    mocked_graph.nodes.return_value = nodes
-    mocked_graph.outcoming = lambda x: mapping[x]
-    mocked_graph.link_weight = lambda x, y: mapping[y].index(x) + 1
-    assert wiz.graph.compute_distance_mapping(mocked_graph) == expected
-
-
-@pytest.mark.parametrize("variant_groups, expected", [
-    (
-        [["foo[V2]", "foo[V1]"]],
-        [("foo[V1]",), ("foo[V2]",)]
-    ),
-    (
-        [["foo[V3]", "foo[V2]", "foo[V1]"]],
-        [
-            ("foo[V2]", "foo[V1]"),
-            ("foo[V3]", "foo[V1]"),
-            ("foo[V3]", "foo[V2]")
-        ]
-    ),
-    (
-        [["foo[V4]", "foo[V3]", "foo[V2]", "foo[V1]"]],
-        [
-            ("foo[V3]", "foo[V2]", "foo[V1]"),
-            ("foo[V4]", "foo[V2]", "foo[V1]"),
-            ("foo[V4]", "foo[V3]", "foo[V1]"),
-            ("foo[V4]", "foo[V3]", "foo[V2]")
-        ]
-    ),
-    (
-        [["foo[V3]==1", "foo[V2]==1", "foo[V1]==1", "foo[V1]==2"]],
-        [
-            ("foo[V2]==1", "foo[V1]==1", "foo[V1]==2"),
-            ("foo[V3]==1", "foo[V1]==1", "foo[V1]==2"),
-            ("foo[V3]==1", "foo[V2]==1")
-        ]
-    ),
-    (
-        [["foo[V3]", "foo[V2]", "foo[V1]"], ["bar[V1]", "bar[V2]"]],
-        [
-            ("foo[V2]", "foo[V1]", "bar[V2]"),
-            ("foo[V2]", "foo[V1]", "bar[V1]"),
-            ("foo[V3]", "foo[V1]", "bar[V2]"),
-            ("foo[V3]", "foo[V1]", "bar[V1]"),
-            ("foo[V3]", "foo[V2]", "bar[V2]"),
-            ("foo[V3]", "foo[V2]", "bar[V1]")
-        ]
-    ),
-    (
-        [
-            ["foo[V3]", "foo[V2]", "foo[V1]"],
-            ["bar[V4]", "bar[V3]", "bar[V2]", "bar[V1]"],
-            ["bim[V2]", "bim[V1]"]
-        ],
-        [
-            ("foo[V2]", "foo[V1]", "bar[V3]", "bar[V2]", "bar[V1]", "bim[V1]"),
-            ("foo[V2]", "foo[V1]", "bar[V3]", "bar[V2]", "bar[V1]", "bim[V2]"),
-            ("foo[V2]", "foo[V1]", "bar[V4]", "bar[V2]", "bar[V1]", "bim[V1]"),
-            ("foo[V2]", "foo[V1]", "bar[V4]", "bar[V2]", "bar[V1]", "bim[V2]"),
-            ("foo[V2]", "foo[V1]", "bar[V4]", "bar[V3]", "bar[V1]", "bim[V1]"),
-            ("foo[V2]", "foo[V1]", "bar[V4]", "bar[V3]", "bar[V1]", "bim[V2]"),
-            ("foo[V2]", "foo[V1]", "bar[V4]", "bar[V3]", "bar[V2]", "bim[V1]"),
-            ("foo[V2]", "foo[V1]", "bar[V4]", "bar[V3]", "bar[V2]", "bim[V2]"),
-            ("foo[V3]", "foo[V1]", "bar[V3]", "bar[V2]", "bar[V1]", "bim[V1]"),
-            ("foo[V3]", "foo[V1]", "bar[V3]", "bar[V2]", "bar[V1]", "bim[V2]"),
-            ("foo[V3]", "foo[V1]", "bar[V4]", "bar[V2]", "bar[V1]", "bim[V1]"),
-            ("foo[V3]", "foo[V1]", "bar[V4]", "bar[V2]", "bar[V1]", "bim[V2]"),
-            ("foo[V3]", "foo[V1]", "bar[V4]", "bar[V3]", "bar[V1]", "bim[V1]"),
-            ("foo[V3]", "foo[V1]", "bar[V4]", "bar[V3]", "bar[V1]", "bim[V2]"),
-            ("foo[V3]", "foo[V1]", "bar[V4]", "bar[V3]", "bar[V2]", "bim[V1]"),
-            ("foo[V3]", "foo[V1]", "bar[V4]", "bar[V3]", "bar[V2]", "bim[V2]"),
-            ("foo[V3]", "foo[V2]", "bar[V3]", "bar[V2]", "bar[V1]", "bim[V1]"),
-            ("foo[V3]", "foo[V2]", "bar[V3]", "bar[V2]", "bar[V1]", "bim[V2]"),
-            ("foo[V3]", "foo[V2]", "bar[V4]", "bar[V2]", "bar[V1]", "bim[V1]"),
-            ("foo[V3]", "foo[V2]", "bar[V4]", "bar[V2]", "bar[V1]", "bim[V2]"),
-            ("foo[V3]", "foo[V2]", "bar[V4]", "bar[V3]", "bar[V1]", "bim[V1]"),
-            ("foo[V3]", "foo[V2]", "bar[V4]", "bar[V3]", "bar[V1]", "bim[V2]"),
-            ("foo[V3]", "foo[V2]", "bar[V4]", "bar[V3]", "bar[V2]", "bim[V1]"),
-            ("foo[V3]", "foo[V2]", "bar[V4]", "bar[V3]", "bar[V2]", "bim[V2]")
-        ]
-    ),
-    (
-        [
-            ["A[V2]==1", "A[V1]==1", "A[V1]==2"],
-            ["B[V3]==1", "B[V2]==1", "B[V1]==1", "B[V2]==2"]
-        ],
-        [
-            ("A[V1]==1", "A[V1]==2", "B[V2]==1", "B[V1]==1", "B[V2]==2"),
-            ("A[V1]==1", "A[V1]==2", "B[V3]==1", "B[V1]==1"),
-            ("A[V1]==1", "A[V1]==2", "B[V3]==1", "B[V2]==1", "B[V2]==2"),
-            ("A[V2]==1", "B[V2]==1", "B[V1]==1", "B[V2]==2"),
-            ("A[V2]==1", "B[V3]==1", "B[V1]==1"),
-            ("A[V2]==1", "B[V3]==1", "B[V2]==1", "B[V2]==2")
-        ]
-    ),
-], ids=[
-    "one-group-of-2",
-    "one-group-of-3",
-    "one-group-of-4",
-    "one-group-with-conflicts",
-    "two-groups",
-    "three-groups",
-    "multiple-groups-with-conflicts",
-])
-def test_generate_variant_combinations(
-    mocker, mocked_graph, variant_groups, expected
-):
-    """Return list of node trimming combinations from variants."""
-    # Suppose that variants are always between square brackets in identifier.
-    mocked_graph.node = lambda _id: mocker.Mock(
-        identifier=_id,
-        package=mocker.Mock(
-            variant_identifier=re.search(r"(?<=\[).+(?=\])", _id).group(0)
-        )
-    )
-
-    results = wiz.graph.generate_variant_combinations(
-        mocked_graph, variant_groups
-    )
-    assert isinstance(results, types.GeneratorType) is True
-    for combination, _expected in six.moves.zip_longest(results, expected):
-        assert combination[0] == mocked_graph
-        assert combination[1] == _expected
-
-
-def test_trim_unreachable_from_graph(
-    mocker, mocked_graph, mocked_graph_remove_node
-):
-    """Remove unreachable nodes from graph based on distance mapping."""
-    mocked_graph.nodes.return_value = [
-        mocker.Mock(identifier="A"),
-        mocker.Mock(identifier="B"),
-        mocker.Mock(identifier="C"),
-        mocker.Mock(identifier="D"),
-        mocker.Mock(identifier="E"),
-        mocker.Mock(identifier="F"),
-    ]
-
-    distance_mapping = {
-        "root": {"distance": 0, "parent": "root"},
-        "A": {"distance": 1, "parent": "root"},
-        "B": {"distance": None, "parent": None},
-        "C": {"distance": 2, "parent": "A"},
-        "D": {"distance": None, "parent": None},
-        "E": {"distance": 3, "parent": "A"},
-        "F": {"distance": 4, "parent": "A"},
+@pytest.fixture()
+def packages(request):
+    """Returned package mapping for testings"""
+    mapping = {
+        "single": _simple_package(),
+        "single-with-namespace": _simple_package_with_namespace(),
+        "many": _several_packages(),
+        "many-with-namespaces": _packages_with_namespace(),
+        "many-with-conditions": _packages_with_conditions(),
+        "conflicting-versions": _packages_with_conflicting_versions(),
+        "conflicting-variants": _packages_with_conflicting_variants(),
     }
 
-    wiz.graph.trim_unreachable_from_graph(mocked_graph, distance_mapping)
+    return mapping[request.param]
 
-    assert mocked_graph_remove_node.call_count == 2
-    mocked_graph_remove_node.assert_any_call("B")
-    mocked_graph_remove_node.assert_any_call("D")
 
-
-@pytest.mark.parametrize("distance_mapping, nodes_removed", [
-    (
-        {
-            "root": {"distance": 0, "parent": "root"},
-            "A": {"distance": 1, "parent": "root"},
-            "B": {"distance": 2, "parent": "root"},
-            "C": {"distance": 3, "parent": "root"},
-            "D": {"distance": None, "parent": None},
-        },
-        ["B"]
-    ),
-    (
-        {
-            "root": {"distance": 0, "parent": "root"},
-            "A": {"distance": 1, "parent": "root"},
-            "B": {"distance": 2, "parent": "root"},
-            "C": {"distance": 3, "parent": "root"},
-            "D": {"distance": 4, "parent": "A"},
-        },
-        []
-    ),
-], ids=[
-    "true",
-    "false",
-])
-def test_trim_invalid_conditions_from_graph(
-    mocker, mocked_graph, mocked_graph_remove_node, distance_mapping,
-    nodes_removed
-):
-    """Remove invalid nodes from graph based on distance mapping."""
-    mocked_graph.find.side_effect = [
-        ["B"], ["C"], ["C"], ["D"],
-    ]
-
-    mocked_graph.nodes.return_value = [
-        mocker.Mock(
-            identifier="A",
-            package=mocker.Mock(conditions=["B", "C"]),
-            parent_identifiers=[]
-
-        ),
-        mocker.Mock(
-            identifier="B",
-            package=mocker.Mock(conditions=["C", "D"]),
-            parent_identifiers=[]
-        ),
-        mocker.Mock(
-            identifier="C",
-            package=mocker.Mock(conditions=[]),
-            parent_identifiers=[]
-        ),
-        mocker.Mock(
-            identifier="D",
-            package=mocker.Mock(conditions=[]),
-            parent_identifiers=[]
-        ),
-    ]
-
-    result = wiz.graph.trim_invalid_from_graph(mocked_graph, distance_mapping)
-    assert result == (len(nodes_removed) > 0)
-
-    assert mocked_graph_remove_node.call_count == len(nodes_removed)
-    for node in nodes_removed:
-        mocked_graph_remove_node.assert_any_call(node)
-
-
-def test_updated_by_distance():
-    """Update nodes based on distance mapping."""
-    identifiers = ["F", "E", "D", "C", "B", "A"]
-
-    distance_mapping = {
-        "root": {"distance": 0, "parent": "root"},
-        "A": {"distance": 1, "parent": "root"},
-        "B": {"distance": None, "parent": None},
-        "C": {"distance": 2, "parent": "A"},
-        "D": {"distance": None, "parent": None},
-        "E": {"distance": 3, "parent": "A"},
-        "F": {"distance": 4, "parent": "A"},
-    }
-
-    result = wiz.graph.updated_by_distance(identifiers, distance_mapping)
-    assert result == ["A", "C", "E", "F"]
-
-
-def test_extract_conflicting_nodes(mocker, mocked_graph):
-    """Extract conflicting nodes for a specific node."""
-    node_mapping = {
-        "A": mocker.Mock(
-            identifier="A",
-            definition=mocker.Mock(qualified_identifier="defB")
-        ),
-        "B": mocker.Mock(
-            identifier="B",
-            definition=mocker.Mock(qualified_identifier="defB")
-        ),
-        "C": mocker.Mock(
-            identifier="C",
-            definition=mocker.Mock(qualified_identifier="defB")
-        ),
-        "D": mocker.Mock(
-            identifier="D",
-            definition=mocker.Mock(qualified_identifier="defA")
-        ),
-        "E": mocker.Mock(
-            identifier="E",
-            definition=mocker.Mock(qualified_identifier="defA")
-        ),
-        "F": mocker.Mock(
-            identifier="F",
-            definition=mocker.Mock(qualified_identifier="defA")
-        )
-    }
-
-    mocked_graph.node = lambda _id: node_mapping[_id]
-    mocked_graph.conflicting_identifiers.return_value = sorted(
-        node_mapping.keys()
-    )
-
-    assert wiz.graph.extract_conflicting_nodes(
-        mocked_graph, node_mapping["F"]
-    ) == [node_mapping["D"], node_mapping["E"]]
-
-    assert wiz.graph.extract_conflicting_nodes(
-        mocked_graph, node_mapping["E"]
-    ) == [node_mapping["D"], node_mapping["F"]]
-
-    assert wiz.graph.extract_conflicting_nodes(
-        mocked_graph, node_mapping["C"]
-    ) == [node_mapping["A"], node_mapping["B"]]
-
-
-def test_combined_requirements(mocker, mocked_graph):
-    """Combine nodes requirements."""
-    requirements = [
-        Requirement("A >= 1"),
-        Requirement("A >= 1, < 2"),
-        Requirement("A == 1.2.3")
-    ]
-
-    nodes = [
-        mocker.Mock(
-            identifier="A==3",
-            parent_identifiers=["B"]
-        ),
-        mocker.Mock(
-            identifier="A==1.9",
-            parent_identifiers=["C"]
-        ),
-        mocker.Mock(
-            identifier="A==1.2.3",
-            parent_identifiers=["D"]
-        )
-    ]
-
-    mocked_graph.link_requirement.side_effect = requirements
-
-    requirement = wiz.graph.combined_requirements(mocked_graph, nodes)
-
-    assert str(requirement) == "A >=1, ==1.2.3, <2"
-
-    assert mocked_graph.link_requirement.call_count == 3
-    mocked_graph.link_requirement.assert_any_call("A==3", "B")
-    mocked_graph.link_requirement.assert_any_call("A==1.9", "C")
-    mocked_graph.link_requirement.assert_any_call("A==1.2.3", "D")
-
-
-def test_combined_requirements_error(mocker, mocked_graph):
-    """Fail to combine nodes requirements from different definition name."""
-    requirements = [
-        Requirement("A >= 1"),
-        Requirement("Z >= 1, < 2"),
-        Requirement("A == 1.2.3")
-    ]
-
-    nodes = [
-        mocker.Mock(
-            identifier="A==3",
-            parent_identifiers=["B"]
-        ),
-        mocker.Mock(
-            identifier="Z==1.9",
-            parent_identifiers=["C"]
-        ),
-        mocker.Mock(
-            identifier="A==1.2.3",
-            parent_identifiers=["D"]
-        )
-    ]
-
-    mocked_graph.link_requirement.side_effect = requirements
-
-    with pytest.raises(wiz.exception.GraphResolutionError):
-        wiz.graph.combined_requirements(mocked_graph, nodes)
-
-    assert mocked_graph.link_requirement.call_count == 2
-    mocked_graph.link_requirement.assert_any_call("A==3", "B")
-    mocked_graph.link_requirement.assert_any_call("Z==1.9", "C")
-
-
-@pytest.mark.parametrize("requirement, namespace, expected", [
-    (
-        Requirement("foo"),
-        "namespace",
-        Requirement("namespace::foo")
-    ),
-    (
-        Requirement("namespace::foo"),
-        "namespace",
-        Requirement("namespace::foo")
-    ),
-    (
-        Requirement("bar"),
-        None,
-        Requirement("bar")
-    ),
-    (
-        Requirement("::bar"),
-        None,
-        Requirement("bar")
-    ),
-], ids=[
-    "implicit-namespace",
-    "explicit-namespace",
-    "implicit-no-namespace",
-    "explicit-no-namespace",
-])
-def test_sanitize_requirement(requirement, namespace, expected):
-    """Mutate the requirement according to package namespaces."""
-    wiz.graph.sanitize_requirement(requirement, namespace)
-    assert requirement == expected
-
-
-def test_extract_conflicting_requirements(mocker, mocked_graph):
-    """Extract conflicting requirements from nodes."""
-    nodes = [
-        mocker.Mock(
-            definition=mocker.Mock(qualified_identifier="foo"),
-            identifier="foo==3.2.1",
-            parent_identifiers=["E", "F"]
-        ),
-        mocker.Mock(
-            definition=mocker.Mock(qualified_identifier="foo"),
-            identifier="foo==4.0.0",
-            parent_identifiers=["G", "H", "I"]
-        ),
-        mocker.Mock(
-            definition=mocker.Mock(qualified_identifier="foo"),
-            identifier="foo==3.0.0",
-            parent_identifiers=["root"]
-        )
-    ]
-
-    # calls for: E, F, G, H, I
-    mocked_graph.exists.side_effect = [False, True, True, True, True]
-
-    # calls for: F, G, H, I, root
-    mocked_graph.link_requirement.side_effect = [
-        Requirement("foo ==3.*"),
-        Requirement("foo >=4, <5"),
-        Requirement("foo >=4, <5"),
-        Requirement("foo"),
-        Requirement("foo==3.0.0"),
-    ]
-
-    conflicts = wiz.graph.extract_conflicting_requirements(mocked_graph, nodes)
-
-    assert mocked_graph.exists.call_count == 5
-    mocked_graph.exists.assert_any_call("E")
-    mocked_graph.exists.assert_any_call("F")
-    mocked_graph.exists.assert_any_call("G")
-    mocked_graph.exists.assert_any_call("H")
-    mocked_graph.exists.assert_any_call("I")
-
-    assert mocked_graph.link_requirement.call_count == 5
-    mocked_graph.link_requirement.assert_any_call("foo==3.2.1", "F")
-    mocked_graph.link_requirement.assert_any_call("foo==4.0.0", "G")
-    mocked_graph.link_requirement.assert_any_call("foo==4.0.0", "H")
-    mocked_graph.link_requirement.assert_any_call("foo==4.0.0", "I")
-    mocked_graph.link_requirement.assert_any_call("foo==3.0.0", "root")
-
-    assert conflicts == [
-        {
-            "graph": mocked_graph,
-            "requirement": Requirement("foo >=4, <5"),
-            "identifiers": {"G", "H"},
-            "conflicts": {"F", "root"}
-        },
-        {
-            "graph": mocked_graph,
-            "requirement": Requirement("foo ==3.0.0"),
-            "identifiers": {"root"},
-            "conflicts": {"G", "H"}
-        },
-        {
-            "graph": mocked_graph,
-            "requirement": Requirement("foo ==3.*"),
-            "identifiers": {"F"},
-            "conflicts": {"G", "H"}
-        }
-    ]
-
-
-def test_extract_conflicting_requirements_error(mocker, mocked_graph):
-    """Fail to extract conflicting requirements from nodes."""
-    nodes = [
-        mocker.Mock(
-            definition=mocker.Mock(qualified_identifier="bar"),
-            identifier="bar==3.2.1",
-            parent_identifiers=["E", "F"]
-        ),
-        mocker.Mock(
-            definition=mocker.Mock(qualified_identifier="foo"),
-            identifier="foo==4.0.0",
-            parent_identifiers=["G", "H", "I"]
-        ),
-        mocker.Mock(
-            definition=mocker.Mock(qualified_identifier="foo"),
-            identifier="foo==3.0.0",
-            parent_identifiers=["root"]
-        )
-    ]
-
-    with pytest.raises(wiz.exception.GraphResolutionError) as error:
-        wiz.graph.extract_conflicting_requirements(mocked_graph, nodes)
-
-    assert (
-        "All nodes should have the same definition identifier when "
-        "attempting to extract conflicting requirements from parent "
-        "nodes [bar, foo]"
-    ) in str(error.value)
-
-    mocked_graph.exists.assert_not_called()
-    mocked_graph.link_requirement.assert_not_called()
-
-
-def test_validate_success(mocked_graph, mocked_updated_by_distance):
-    """Validate graph with remaining errors."""
-    mocked_graph.error_identifiers.return_value = []
-    mocked_updated_by_distance.return_value = ["A", "B"]
-
-    assert wiz.graph.validate(mocked_graph, "__DISTANCE_MAPPING__") is None
-
-    mocked_updated_by_distance.assert_not_called()
-    mocked_graph.errors.assert_not_called()
-
-
-def test_validate_error(mocked_graph, mocked_updated_by_distance):
-    """Validate graph with remaining errors."""
-    error_mapping = {
-        "A": [Exception("Error1"), Exception("Error2")],
-        "B": [Exception("Error3")]
-    }
-
-    mocked_graph.error_identifiers.return_value = ["__ERRORS__"]
-    mocked_graph.errors = lambda _id: error_mapping[_id]
-    mocked_updated_by_distance.return_value = ["A", "B"]
-
-    with pytest.raises(wiz.exception.GraphResolutionError) as error:
-        wiz.graph.validate(mocked_graph, "__DISTANCE_MAPPING__")
-
-    mocked_updated_by_distance.assert_called_once_with(
-        ["__ERRORS__"], "__DISTANCE_MAPPING__"
-    )
-
-    assert (
-       "The dependency graph could not be resolved due to the following "
-       "error(s):\n"
-       "  * A: Error1\n"
-       "  * A: Error2\n"
-    ) in str(error.value)
-
-
-def test_validate_empty(mocked_graph, mocked_updated_by_distance):
-    """Validate graph with remaining errors."""
-    mocked_graph.error_identifiers.return_value = ["__ERRORS__"]
-    mocked_updated_by_distance.return_value = []
-
-    with pytest.raises(Exception) as error:
-        wiz.graph.validate(mocked_graph, "__DISTANCE_MAPPING__")
-
-    mocked_updated_by_distance.assert_called_once_with(
-        ["__ERRORS__"], "__DISTANCE_MAPPING__"
-    )
-    mocked_graph.errors.assert_not_called()
-
-    assert (
-        "The dependency graph does not contain any valid packages."
-        in str(error)
-    )
-
-
-@pytest.mark.parametrize("identifiers, distance_mapping, expected", [
-    (
-        [],
-        {"root": {"distance": 0, "parent": "root"}},
-        []
-    ),
-    (
-        ["A"],
-        {
-            "root": {"distance": 0, "parent": "root"},
-            "A": {"distance": 1, "parent": "root"}
-        },
-        ["A"]
-    ),
-    (
-        ["A", "B"],
-        {
-            "root": {"distance": 0, "parent": "root"},
-            "A": {"distance": 1, "parent": "root"},
-            "B": {"distance": 2, "parent": "root"}
-        },
-        ["B", "A"],
-    ),
-    (
-        ["A", "B", "C"],
-        {
-            "root": {"distance": 0, "parent": "root"},
-            "A": {"distance": 1, "parent": "root"},
-            "B": {"distance": 2, "parent": "root"},
-            "C": {"distance": 3, "parent": "root"}
-        },
-        ["C", "B", "A"]
-    ),
-    (
-        ["A", "B", "C", "D", "E", "F", "G"],
-        {
-            "root": {"distance": 0, "parent": "root"},
-            "A": {"distance": 1, "parent": "root"},
-            "B": {"distance": 2, "parent": "root"},
-            "C": {"distance": 2, "parent": "A"},
-            "D": {"distance": 3, "parent": "A"},
-            "E": {"distance": 4, "parent": "D"},
-            "F": {"distance": 4, "parent": "B"},
-            "G": {"distance": 5, "parent": "B"},
-        },
-        ["G", "E", "F", "D", "B", "C", "A"]
-    ),
-    (
-        ["A", "B", "C", "D", "E"],
-        {
-            "root": {"distance": 0, "parent": "root"},
-            "A": {"distance": 1, "parent": "root"},
-            "B": {"distance": 2, "parent": "root"},
-            "C": {"distance": 2, "parent": "A"},
-            "D": {"distance": None, "parent": "F"},
-            "E": {"distance": None, "parent": "G"},
-        },
-        ["B", "C", "A"]
-    )
-], ids=[
-    "no-node",
-    "one-node",
-    "two-nodes",
-    "three-nodes",
-    "multi-levels",
-    "unreachable-nodes",
-])
-def test_extract_ordered_packages(
-    mocker, mocked_graph, identifiers, distance_mapping, expected
-):
-    """Extract ordered packages from graph."""
-    package_mapping = {
-        _id: wiz.package.Package(
-            wiz.definition.Definition({"identifier": _id})
-        ) for _id in identifiers
-    }
-
-    nodes = [
-        mocker.Mock(identifier=_id, package=package_mapping[_id])
-        for _id in identifiers
-    ]
-    mocked_graph.nodes.return_value = nodes
-
-    result = wiz.graph.extract_ordered_packages(mocked_graph, distance_mapping)
-    assert result == [package_mapping[_id] for _id in expected]
-
-
-def test_graph_node():
-    """Return node from graph via identifier."""
-    graph = wiz.graph.Graph(None)
-    graph._node_mapping = {"A": "_nodeA"}
-
-    assert graph.node("A") == "_nodeA"
-    assert graph.node("B") is None
-
-
-def test_graph_nodes():
-    """Return nodes from graph."""
-    graph = wiz.graph.Graph(None)
-    graph._node_mapping = {"A": "_nodeA", "B": "_nodeB", "C": "_nodeC"}
-
-    assert sorted(graph.nodes()) == ["_nodeA", "_nodeB", "_nodeC"]
-
-
-def test_graph_exists():
-    """Indicate whether node exists in graph."""
-    graph = wiz.graph.Graph(None)
-    graph._node_mapping = {"A": "_nodeA"}
-
-    assert graph.exists("A") is True
-    assert graph.exists("B") is False
-
-
-@pytest.mark.parametrize("requirement, expected", [
-    (
-        Requirement("Z"),
-        []
-    ),
-    (
-        Requirement("A"),
-        ["A==0.1.0", "A==2.4.5"]
-    ),
-    (
-        Requirement("Name1::B"),
-        ["Name1::B"]
-    ),
-    (
-        Requirement("A > 1"),
-        ["A==2.4.5"]
-    )
-], ids=[
-    "un-found",
-    "match-definition-name",
-    "match-namespace",
-    "match-versions"
-])
-def test_graph_find_matching_identifiers(
-    requirement, expected, mocker
-):
-    """Find matching identifiers from requirement."""
-    graph = wiz.graph.Graph(None)
-    graph._node_mapping = {
-        "A==0.1.0": mocker.Mock(
-            definition=mocker.Mock(qualified_identifier="A"),
-            package=mocker.Mock(
-                version=Version("0.1.0"),
-                identifier="A==0.1.0"
-            )
-        ),
-        "A==2.4.5": mocker.Mock(
-            definition=mocker.Mock(qualified_identifier="A"),
-            package=mocker.Mock(
-                version=Version("2.4.5"),
-                identifier="A==2.4.5"
-            )
-        ),
-        "Name1::B": mocker.Mock(
-            definition=mocker.Mock(qualified_identifier="Name1::B"),
-            package=mocker.Mock(
-                version=None,
-                identifier="Name1::B"
-            )
-        ),
-        "B==1": mocker.Mock(
-            definition=mocker.Mock(qualified_identifier="B"),
-            package=mocker.Mock(
-                version=Version("1"),
-                identifier="B==1"
-            )
-        ),
-    }
-
-    result = graph.find(requirement)
-    assert result == expected
-
-
-def test_graph_variant_groups(mocker):
-    """Extract variants from graph."""
-    graph = wiz.graph.Graph(None)
-    assert graph.variant_groups() == []
-
-    graph = wiz.graph.Graph(None)
-    graph._node_mapping = {
-        "A[V1]==0.1.0": mocker.Mock(
-            identifier="A[V1]==0.1.0",
-            package=mocker.Mock(
-                variant_identifier="V1",
-                version=Version("0.1.0")
-            )
-        ),
-        "A[V2]==0.1.0": mocker.Mock(
-            identifier="A[V2]==0.1.0",
-            package=mocker.Mock(
-                variant_identifier="V2",
-                version=Version("0.1.0")
-            )
-        ),
-        "B[V1]==0.1.0": mocker.Mock(
-            identifier="B[V1]==0.1.0",
-            package=mocker.Mock(
-                variant_identifier="V1",
-                version=Version("0.1.0")
-            )
-        ),
-        "B[V1]==0.2.0": mocker.Mock(
-            identifier="B[V1]==0.2.0",
-            package=mocker.Mock(
-                variant_identifier="V1",
-                version=Version("0.2.0")
-            )
-        ),
-        "B[V2]==0.1.0": mocker.Mock(
-            identifier="B[V2]==0.1.0",
-            package=mocker.Mock(
-                variant_identifier="V2",
-                version=Version("0.1.0")
-            )
-        ),
-        "C[V1]==0.1.0": mocker.Mock(
-            identifier="C[V1]==0.1.0",
-            package=mocker.Mock(
-                variant_identifier="V1",
-                version=Version("0.1.0")
-            )
-        ),
-        "D[V1]==0.1.0": mocker.Mock(
-            identifier="D[V1]==0.1.0",
-            package=mocker.Mock(
-                variant_identifier="V1",
-                version=Version("0.1.0")
-            )
-        ),
-        "D[V1]==0.2.0": mocker.Mock(
-            identifier="D[V1]==0.2.0",
-            package=mocker.Mock(
-                variant_identifier="V1",
-                version=Version("0.2.0")
-            )
-        )
-    }
-    graph._variants_per_definition = {
-        "A": ["A[V1]==0.1.0", "A[V2]==0.1.0", "A[V2]==0.1.0"],
-        "B": ["B[V1]==0.1.0", "B[V2]==0.1.0", "B[V1]==0.2.0"],
-        "C": ["C[V1]==0.1.0"],
-        "D": ["D[V1]==0.1.0", "D[V1]==0.2.0"]
-    }
-    assert graph.variant_groups() == [
-        ["A[V2]==0.1.0", "A[V1]==0.1.0"],
-        ["B[V1]==0.2.0", "B[V1]==0.1.0", "B[V2]==0.1.0"]
-    ]
-
-
-def test_graph_outcoming():
-    """Fetch outcoming nodes from node identifier."""
-    graph = wiz.graph.Graph(None)
-    assert graph.outcoming("A") == []
-
-    graph = wiz.graph.Graph(None)
-    graph._link_mapping = {"A": {"B": "LINK"}}
-    assert graph.outcoming("A") == []
-
-    graph = wiz.graph.Graph(None)
-    graph._node_mapping = {"A": "_A"}
-    graph._link_mapping = {"A": {"B": "LINK"}}
-    assert graph.outcoming("A") == []
-
-    graph = wiz.graph.Graph(None)
-    graph._node_mapping = {"A": "_A", "B": "_B"}
-    graph._link_mapping = {"A": {"B": "LINK"}}
-    assert graph.outcoming("A") == ["B"]
-
-
-def test_graph_link_weight():
-    """Fetch weight from nodes link."""
-    graph = wiz.graph.Graph(None)
-    graph._link_mapping = {
-        "A": {
-            "B": {"requirement": Requirement("A"), "weight": 3},
-            "C": {"requirement": Requirement("A>2"), "weight": 2}
-        }
-    }
-    assert graph.link_weight("B", "A") == 3
-    assert graph.link_weight("C", "A") == 2
-
-
-def test_graph_requirement_weight():
-    """Fetch requirement from nodes link."""
-    requirements = [
-        Requirement("A"), Requirement("A>2")
-    ]
-
-    graph = wiz.graph.Graph(None)
-    graph._link_mapping = {
-        "A": {
-            "B": {"requirement": requirements[0], "weight": 3},
-            "C": {"requirement": requirements[1], "weight": 2}
-        }
-    }
-
-    assert graph.link_requirement("B", "A") == requirements[0]
-    assert graph.link_requirement("C", "A") == requirements[1]
-
-
-@pytest.mark.parametrize("definition_mapping, node_mapping, expected", [
-    (
-        {"defA": ["nodeA"], "defB": ["nodeB"]},
-        {"nodeA": "_nodeA", "nodeB": "_nodeB"},
-        []
-    ),
-    (
-        {"defA": ["nodeA1", "nodeA2"], "defB": ["nodeB"]},
-        {"nodeA1": "_nodeA1", "nodeA2": "_nodeA2", "nodeB": "_nodeB"},
-        ["nodeA1", "nodeA2"]
-    ),
-    (
-        {"defA": ["nodeA1", "nodeA2"], "defB": ["nodeB"]},
-        {"nodeA1": "_nodeA1", "nodeB": "_nodeB"},
-        []
-    )
-], ids=[
-    "without-conflicts",
-    "with-two-conflicts",
-    "with-conflicting-node-removed"
-])
-def test_graph_conflicts(definition_mapping, node_mapping, expected):
-    """Extract conflicting nodes from graph."""
-    graph = wiz.graph.Graph(None)
-    graph._node_mapping = node_mapping
-    graph._identifiers_per_definition = definition_mapping
-
-    assert graph.conflicting_identifiers() == expected
-
-
-def test_graph_update_from_requirements(
-    mocker, mocked_resolver, mocked_package_extract
-):
-    """Update graph from requirements."""
-    graph = wiz.graph.Graph(mocked_resolver)
-
-    _mapping = {
-        "A==0.2.0": wiz.package.Package(
-            wiz.definition.Definition({
-                "identifier": "A",
-                "version": "0.2.0"
-            })
-        ),
-        "B==2.1.1": wiz.package.Package(
-            wiz.definition.Definition({
-                "identifier": "B",
-                "version": "2.1.1"
-            })
-        ),
-    }
-
-    mocked_package_extract.side_effect = [
-        [_mapping["A==0.2.0"]],
-        [_mapping["B==2.1.1"]]
-    ]
-
-    graph.update_from_requirements(
-        [Requirement("A"), Requirement("B>=2")], graph.ROOT
-    )
-
-    assert graph.data() == {
-        "identifier": mocker.ANY,
-        "node_mapping": {
-            "A==0.2.0": {
-                "package": {
-                    "identifier": "A==0.2.0",
-                    "version": "0.2.0"
-                },
-                "parents": ["root"]
-            },
-            "B==2.1.1": {
-                "package": {
-                    "identifier": "B==2.1.1",
-                    "version": "2.1.1"
-                },
-                "parents": ["root"]
-            }
-        },
-        "link_mapping": {
-            "root": {
-                "A==0.2.0": {"requirement": Requirement("A"), "weight": 1},
-                "B==2.1.1": {"requirement": Requirement("B >=2"), "weight": 2}
-            }
-        },
-        "identifiers_per_definition": {
-            "A": ["A==0.2.0"],
-            "B": ["B==2.1.1"]
-        },
-        "variants_per_definition": {},
-        "conditioned_nodes": [],
-        "namespace_count": {},
-        "error_mapping": {}
-    }
-
-
-def test_graph_update_from_requirements_with_dependencies(
-    mocker, mocked_resolver, mocked_package_extract
-):
-    """Update graph from requirements with dependency requirements."""
-    graph = wiz.graph.Graph(mocked_resolver)
-
-    _mapping = {
+def _simple_package():
+    """Create one simple package."""
+    return {
         "A==0.1.0": wiz.package.Package(
             wiz.definition.Definition({
                 "identifier": "A",
                 "version": "0.1.0",
-                "requirements": ["B>=2", "C"],
-            })
-        ),
-        "B==3.0.0": wiz.package.Package(
-            wiz.definition.Definition({
-                "identifier": "B",
-                "version": "3.0.0",
-            })
-        ),
-        "C==1.2.3": wiz.package.Package(
-            wiz.definition.Definition({
-                "identifier": "C",
-                "version": "1.2.3",
-                "requirements": ["D"],
-            })
-        ),
-        "D==0.1.0": wiz.package.Package(
-            wiz.definition.Definition({
-                "identifier": "D",
-                "version": "0.1.0",
-                "requirements": ["E"],
-            })
-        ),
-        "E==0.2.0": wiz.package.Package(
-            wiz.definition.Definition({
-                "identifier": "E",
-                "version": "0.2.0",
-            })
-        ),
-    }
-
-    mocked_package_extract.side_effect = [
-        [_mapping["A==0.1.0"]],
-        [_mapping["B==3.0.0"]],
-        [_mapping["C==1.2.3"]],
-        [_mapping["D==0.1.0"]],
-        [_mapping["E==0.2.0"]],
-    ]
-
-    graph.update_from_requirements([Requirement("A")], graph.ROOT)
-
-    assert graph.data() == {
-        "identifier": mocker.ANY,
-        "node_mapping": {
-            "A==0.1.0": {
-                "package": {
-                    "identifier": "A==0.1.0",
-                    "version": "0.1.0",
-                    "requirements": ["B>=2", "C"]
-                },
-                "parents": ["root"]
-            },
-            "B==3.0.0": {
-                "package": {
-                    "identifier": "B==3.0.0",
-                    "version": "3.0.0",
-                },
-                "parents": ["A==0.1.0"]
-            },
-            "C==1.2.3": {
-                "package": {
-                    "identifier": "C==1.2.3",
-                    "version": "1.2.3",
-                    "requirements": ["D"]
-                },
-                "parents": ["A==0.1.0"]
-            },
-            "D==0.1.0": {
-                "package": {
-                    "identifier": "D==0.1.0",
-                    "version": "0.1.0",
-                    "requirements": ["E"]
-                },
-                "parents": ["C==1.2.3"]
-            },
-            "E==0.2.0": {
-                "package": {
-                    "identifier": "E==0.2.0",
-                    "version": "0.2.0",
-                },
-                "parents": ["D==0.1.0"]
-            }
-        },
-        "link_mapping": {
-            "root": {
-                "A==0.1.0": {"requirement": Requirement("A"), "weight": 1}
-            },
-            "A==0.1.0": {
-                "B==3.0.0": {"requirement": Requirement("B>=2"), "weight": 1},
-                "C==1.2.3": {"requirement": Requirement("C"), "weight": 2}
-            },
-            "C==1.2.3": {
-                "D==0.1.0": {"requirement": Requirement("D"), "weight": 1},
-            },
-            "D==0.1.0": {
-                "E==0.2.0": {"requirement": Requirement("E"), "weight": 1},
-            }
-        },
-        "identifiers_per_definition": {
-            "A": ["A==0.1.0"],
-            "B": ["B==3.0.0"],
-            "C": ["C==1.2.3"],
-            "D": ["D==0.1.0"],
-            "E": ["E==0.2.0"]
-        },
-        "variants_per_definition": {},
-        "conditioned_nodes": [],
-        "namespace_count": {},
-        "error_mapping": {}
-    }
-
-
-def test_graph_update_from_requirements_with_variants(
-    mocker, mocked_resolver, mocked_package_extract
-):
-    """Update graph from requirements with variants of definition."""
-    graph = wiz.graph.Graph(mocked_resolver)
-
-    definition = wiz.definition.Definition({
-        "identifier": "A",
-        "version": "0.2.0",
-        "variants": [
-            {"identifier": "V1"},
-            {"identifier": "V2"},
-            {"identifier": "V3"},
-        ]
-    })
-
-    _mapping = {
-        "A[V1]==0.2.0": wiz.package.Package(definition, variant_index=0),
-        "A[V2]==0.2.0": wiz.package.Package(definition, variant_index=1),
-        "A[V3]==0.2.0": wiz.package.Package(definition, variant_index=2),
-    }
-
-    mocked_package_extract.side_effect = [
-        [
-            _mapping["A[V1]==0.2.0"],
-            _mapping["A[V2]==0.2.0"],
-            _mapping["A[V3]==0.2.0"]
-        ],
-    ]
-
-    graph.update_from_requirements([Requirement("A")], graph.ROOT)
-
-    assert graph.data() == {
-        "identifier": mocker.ANY,
-        "node_mapping": {
-            "A[V1]==0.2.0": {
-                "package": {
-                    "identifier": "A[V1]==0.2.0",
-                    "version": "0.2.0",
-                    "variant-identifier": "V1",
-                },
-                "parents": ["root"]
-            },
-            "A[V2]==0.2.0": {
-                "package": {
-                    "identifier": "A[V2]==0.2.0",
-                    "version": "0.2.0",
-                    "variant-identifier": "V2",
-                },
-                "parents": ["root"]
-            },
-            "A[V3]==0.2.0": {
-                "package": {
-                    "identifier": "A[V3]==0.2.0",
-                    "version": "0.2.0",
-                    "variant-identifier": "V3",
-                },
-                "parents": ["root"]
-            },
-        },
-        "link_mapping": {
-            "root": {
-                "A[V1]==0.2.0": {"requirement": Requirement("A"), "weight": 1},
-                "A[V2]==0.2.0": {"requirement": Requirement("A"), "weight": 1},
-                "A[V3]==0.2.0": {"requirement": Requirement("A"), "weight": 1}
-            },
-        },
-        "identifiers_per_definition": {
-            "A": ["A[V1]==0.2.0", "A[V2]==0.2.0", "A[V3]==0.2.0"],
-        },
-        "variants_per_definition": {
-            "A": ["A[V1]==0.2.0", "A[V2]==0.2.0", "A[V3]==0.2.0"],
-        },
-        "conditioned_nodes": [],
-        "namespace_count": {},
-        "error_mapping": {}
-    }
-
-
-def test_graph_update_from_requirements_with_namespaces(
-    mocker, mocked_resolver, mocked_package_extract
-):
-    """Update graph from requirements with namespaces."""
-    mocked_resolver.definition_mapping = {
-        "__namespace__": {
-            "A": ["Foo"],
-            "B": ["Foo", "Bar"],
-        }
-    }
-
-    graph = wiz.graph.Graph(mocked_resolver)
-
-    _mapping = {
-        "Foo::A==0.2.0": wiz.package.Package(
-            wiz.definition.Definition({
-                "identifier": "A",
-                "version": "0.2.0",
-                "namespace": "Foo",
-            })
-        ),
-        "Foo::B==2.1.1": wiz.package.Package(
-            wiz.definition.Definition({
-                "identifier": "B",
-                "version": "2.1.1",
-                "namespace": "Foo",
-            })
+            }),
         )
     }
 
+
+def _simple_package_with_namespace():
+    """Create one simple package with namespace."""
+    return {
+        "foo::A==0.1.0": wiz.package.Package(
+            wiz.definition.Definition({
+                "identifier": "A",
+                "namespace": "foo",
+                "version": "0.1.0",
+            }),
+        )
+    }
+
+
+def _several_packages():
+    """Create several packages with dependencies."""
+    return {
+        "A==0.1.0": wiz.package.Package(
+            wiz.definition.Definition({
+                "identifier": "A",
+                "version": "0.1.0",
+                "requirements": ["B"]
+            }),
+        ),
+        "B==1.2.3": wiz.package.Package(
+            wiz.definition.Definition({
+                "identifier": "B",
+                "version": "1.2.3",
+                "requirements": ["C", "D >1"]
+            }),
+        ),
+        "C": wiz.package.Package(
+            wiz.definition.Definition({
+                "identifier": "C",
+            }),
+        ),
+        "D==4.1.0": wiz.package.Package(
+            wiz.definition.Definition({
+                "identifier": "D",
+                "version": "4.1.0",
+            }),
+        ),
+    }
+
+
+def _packages_with_namespace():
+    """Create several packages with dependencies and namespaces."""
+    return {
+        "foo::A==0.1.0": wiz.package.Package(
+            wiz.definition.Definition({
+                "identifier": "A",
+                "namespace": "foo",
+                "version": "0.1.0",
+                "requirements": ["bar::B"]
+            }),
+        ),
+        "bar::B==1.2.3": wiz.package.Package(
+            wiz.definition.Definition({
+                "identifier": "B",
+                "namespace": "bar",
+                "version": "1.2.3",
+                "requirements": ["foo::C", "D >1"]
+            }),
+        ),
+        "foo::C": wiz.package.Package(
+            wiz.definition.Definition({
+                "identifier": "C",
+                "namespace": "foo",
+            }),
+        ),
+        "D==4.1.0": wiz.package.Package(
+            wiz.definition.Definition({
+                "identifier": "D",
+                "version": "4.1.0",
+            }),
+        ),
+    }
+
+
+def _packages_with_conditions():
+    """Create several packages with dependencies and conditions."""
+    return {
+        "A==0.1.0": wiz.package.Package(
+            wiz.definition.Definition({
+                "identifier": "A",
+                "version": "0.1.0",
+                "requirements": ["B"],
+                "conditions": ["E"]
+            }),
+        ),
+        "B==1.2.3": wiz.package.Package(
+            wiz.definition.Definition({
+                "identifier": "B",
+                "version": "1.2.3",
+                "requirements": ["C", "D >1"]
+            }),
+        ),
+        "C": wiz.package.Package(
+            wiz.definition.Definition({
+                "identifier": "C",
+            }),
+        ),
+        "D==4.1.0": wiz.package.Package(
+            wiz.definition.Definition({
+                "identifier": "D",
+                "version": "4.1.0",
+            }),
+        ),
+        "E": wiz.package.Package(
+            wiz.definition.Definition({
+                "identifier": "E",
+                "requirements": ["F"],
+            }),
+        ),
+        "F==13": wiz.package.Package(
+            wiz.definition.Definition({
+                "identifier": "F",
+                "version": "13",
+            }),
+        ),
+        "G": wiz.package.Package(
+            wiz.definition.Definition({
+                "identifier": "G",
+                "conditions": ["F", "D"]
+            }),
+        ),
+        "H": wiz.package.Package(
+            wiz.definition.Definition({
+                "identifier": "H",
+                "conditions": ["incorrect"]
+            }),
+        ),
+    }
+
+
+def _packages_with_conflicting_versions():
+    """Create several packages with conflicting versions."""
+    return {
+        "A==0.1.0": wiz.package.Package(
+            wiz.definition.Definition({
+                "identifier": "A",
+                "version": "0.1.0",
+                "requirements": ["B"]
+            }),
+        ),
+        "B==1.2.3": wiz.package.Package(
+            wiz.definition.Definition({
+                "identifier": "B",
+                "version": "1.2.3",
+                "requirements": [
+                    "C",
+                    "D >= 3, <4"
+                ]
+            }),
+        ),
+        "C": wiz.package.Package(
+            wiz.definition.Definition({
+                "identifier": "C",
+            }),
+        ),
+        "D==3.1.0": wiz.package.Package(
+            wiz.definition.Definition({
+                "identifier": "D",
+                "version": "3.1.0",
+            }),
+        ),
+        "D==3.2.0": wiz.package.Package(
+            wiz.definition.Definition({
+                "identifier": "D",
+                "version": "3.2.0",
+            }),
+        ),
+        "D==4.1.0": wiz.package.Package(
+            wiz.definition.Definition({
+                "identifier": "D",
+                "version": "4.1.0",
+            }),
+        )
+    }
+
+
+def _packages_with_conflicting_variants():
+    """Create several packages with conflicting variants."""
+    definition1 = wiz.definition.Definition({
+        "identifier": "A",
+        "variants": [
+            {"identifier": "V3"},
+            {"identifier": "V2"},
+            {"identifier": "V1"},
+        ]
+    })
+
+    definition2 = wiz.definition.Definition({
+        "identifier": "B",
+        "version": "1.2.3",
+        "variants": [
+            {"identifier": "V2"},
+            {"identifier": "V1"},
+        ],
+        "requirements": [
+            "C",
+        ]
+    })
+
+    return {
+        "A[V3]": wiz.package.Package(
+            definition1, variant_index=0
+        ),
+        "A[V2]": wiz.package.Package(
+            definition1, variant_index=1
+        ),
+        "A[V1]": wiz.package.Package(
+            definition1, variant_index=2
+        ),
+        "B[V2]==1.2.3": wiz.package.Package(
+            definition2, variant_index=0
+        ),
+        "B[V1]==1.2.3": wiz.package.Package(
+            definition2, variant_index=1
+        ),
+        "C": wiz.package.Package(
+            wiz.definition.Definition({
+                "identifier": "C",
+            }),
+        )
+    }
+
+
+def test_graph_empty(mocked_resolver):
+    """Create an empty graph."""
+    graph = wiz.graph.Graph(mocked_resolver)
+
+    assert graph.resolver == mocked_resolver
+    assert graph.nodes() == []
+    assert graph.conflicting() == set()
+    assert graph.conflicting_variant_groups() == []
+    assert graph.conditioned_nodes() == []
+    assert graph.errors() == {}
+    assert graph.data() == {
+        "node_mapping": {},
+        "link_mapping": {},
+        "error_mapping": {},
+        "conditioned_nodes": [],
+    }
+
+
+def test_graph_copy():
+    """Copy a graph while referencing the same resolver instance."""
+    resolver = wiz.graph.Resolver({})
+
+    graph = wiz.graph.Graph(resolver)
+    assert graph.resolver == resolver
+
+    _graph = copy.deepcopy(graph)
+    assert _graph.resolver == resolver
+
+
+@pytest.mark.parametrize("packages", ["many"], indirect=True)
+def test_graph_nodes(mocked_resolver, mocked_package_extract, packages):
+    """Retrieve nodes within a simple graph."""
+    # Set requirements and expected package extraction for test.
+    requirements = [Requirement("A")]
     mocked_package_extract.side_effect = [
-        [_mapping["Foo::A==0.2.0"]],
-        [_mapping["Foo::B==2.1.1"]]
+        [packages["A==0.1.0"]], [packages["B==1.2.3"]], [packages["C"]],
+        [packages["D==4.1.0"]]
     ]
 
-    graph.update_from_requirements(
-        [Requirement("A"), Requirement("B>=2")], graph.ROOT
+    # Create graph.
+    graph = wiz.graph.Graph(mocked_resolver)
+    graph.update_from_requirements(requirements)
+
+    nodes = [
+        wiz.graph.Node(packages["A==0.1.0"], parent_identifiers={"root"}),
+        wiz.graph.Node(packages["B==1.2.3"], parent_identifiers={"A==0.1.0"}),
+        wiz.graph.Node(packages["C"], parent_identifiers={"B==1.2.3"}),
+        wiz.graph.Node(packages["D==4.1.0"], parent_identifiers={"B==1.2.3"})
+    ]
+
+    assert graph.node("A==0.1.0") == nodes[0]
+    assert graph.exists("A==0.1.0") is True
+
+    assert graph.node("B==1.2.3") == nodes[1]
+    assert graph.exists("B==1.2.3") is True
+
+    assert graph.node("C") == nodes[2]
+    assert graph.exists("C") is True
+
+    assert graph.node("D==4.1.0") == nodes[3]
+    assert graph.exists("D==4.1.0") is True
+
+    assert graph.node("whatever") is None
+    assert graph.exists("whatever") is False
+
+    assert sorted(graph.nodes(), key=lambda n: n.identifier) == nodes
+    assert graph.nodes(definition_identifier="A") == [nodes[0]]
+    assert graph.nodes(definition_identifier="B") == [nodes[1]]
+    assert graph.nodes(definition_identifier="C") == [nodes[2]]
+    assert graph.nodes(definition_identifier="D") == [nodes[3]]
+    assert graph.nodes(definition_identifier="whatever") == []
+
+
+@pytest.mark.parametrize("packages", ["conflicting-versions"], indirect=True)
+def test_graph_nodes_with_version_conflicts(
+    mocked_resolver, mocked_package_extract, packages
+):
+    """Retrieve nodes within a simple graph with conflicting versions."""
+    # Set requirements and expected package extraction for test.
+    requirements = [Requirement("D"), Requirement("D==3.*"), Requirement("C")]
+    mocked_package_extract.side_effect = [
+        [packages["D==4.1.0"]], [packages["D==3.2.0"]], [packages["C"]]
+    ]
+
+    # Create graph.
+    graph = wiz.graph.Graph(mocked_resolver)
+    graph.update_from_requirements(requirements)
+
+    nodes = [
+        wiz.graph.Node(packages["C"], parent_identifiers={"root"}),
+        wiz.graph.Node(packages["D==3.2.0"], parent_identifiers={"root"}),
+        wiz.graph.Node(packages["D==4.1.0"], parent_identifiers={"root"}),
+    ]
+
+    assert graph.node("C") == nodes[0]
+    assert graph.exists("C") is True
+
+    assert graph.node("D==3.2.0") == nodes[1]
+    assert graph.exists("D==3.2.0") is True
+
+    assert graph.node("D==4.1.0") == nodes[2]
+    assert graph.exists("D==4.1.0") is True
+
+    assert graph.node("whatever") is None
+    assert graph.exists("whatever") is False
+
+    assert sorted(graph.nodes(), key=lambda n: n.identifier) == nodes
+    assert graph.nodes(definition_identifier="C") == [nodes[0]]
+    assert sorted(
+        graph.nodes(definition_identifier="D"), key=lambda n: n.identifier
+    ) == [nodes[1], nodes[2]]
+    assert graph.nodes(definition_identifier="whatever") == []
+
+
+@pytest.mark.parametrize("packages", ["conflicting-variants"], indirect=True)
+def test_graph_nodes_with_variant_conflicts(
+    mocked_resolver, mocked_package_extract, packages
+):
+    """Retrieve nodes within a simple graph with conflicting variants."""
+    requirements = [Requirement("A"), Requirement("B[V1]")]
+    mocked_package_extract.side_effect = [
+        [packages["A[V3]"],  packages["A[V2]"], packages["A[V1]"]],
+        [packages["B[V1]==1.2.3"]], [packages["C"]],
+    ]
+
+    # Create graph.
+    graph = wiz.graph.Graph(mocked_resolver)
+    graph.update_from_requirements(requirements)
+
+    nodes = [
+        wiz.graph.Node(packages["A[V1]"], parent_identifiers={"root"}),
+        wiz.graph.Node(packages["A[V2]"], parent_identifiers={"root"}),
+        wiz.graph.Node(packages["A[V3]"], parent_identifiers={"root"}),
+        wiz.graph.Node(packages["B[V1]==1.2.3"], parent_identifiers={"root"}),
+        wiz.graph.Node(packages["C"], parent_identifiers={"B[V1]==1.2.3"}),
+    ]
+
+    assert graph.node("A[V1]") == nodes[0]
+    assert graph.exists("A[V1]") is True
+
+    assert graph.node("A[V2]") == nodes[1]
+    assert graph.exists("A[V2]") is True
+
+    assert graph.node("A[V3]") == nodes[2]
+    assert graph.exists("A[V3]") is True
+
+    assert graph.node("B[V1]==1.2.3") == nodes[3]
+    assert graph.exists("B[V1]==1.2.3") is True
+
+    assert graph.node("C") == nodes[4]
+    assert graph.exists("C") is True
+
+    assert graph.node("whatever") is None
+    assert graph.exists("whatever") is False
+
+    assert sorted(graph.nodes(), key=lambda n: n.identifier) == nodes
+    assert sorted(
+        graph.nodes(definition_identifier="A"), key=lambda n: n.identifier
+    ) == [nodes[0], nodes[1], nodes[2]]
+    assert graph.nodes(definition_identifier="B") == [nodes[3]]
+    assert graph.nodes(definition_identifier="C") == [nodes[4]]
+    assert graph.nodes(definition_identifier="whatever") == []
+
+
+@pytest.mark.parametrize(
+    "packages, identifier, requirement", [
+        ("single", "A==0.1.0", Requirement("::A==0.1.*")),
+        ("single-with-namespace", "foo::A==0.1.0", Requirement("foo::A==0.1.*"))
+    ],
+    ids=["single", "single-with-namespace"],
+    indirect=["packages"]
+)
+def test_graph_link_requirement(
+    mocked_resolver, mocked_package_extract, packages, identifier, requirement
+):
+    """Retrieve link requirements within a simple graph."""
+    # Set requirements and expected package extraction for test.
+    requirements = [Requirement("A==0.1.*")]
+    mocked_package_extract.side_effect = [[packages[identifier]]]
+
+    # Create graph.
+    graph = wiz.graph.Graph(mocked_resolver)
+    graph.update_from_requirements(requirements)
+
+    assert graph.link_requirement(identifier, "root") == requirement
+
+    with pytest.raises(ValueError) as error:
+        graph.link_requirement(identifier, "whatever")
+    assert "No link recorded for node: 'whatever'" in str(error)
+
+    with pytest.raises(ValueError) as error:
+        graph.link_requirement("whatever", "root")
+    assert "No link recorded for node: 'whatever'" in str(error)
+
+
+@pytest.mark.parametrize(
+    "packages, identifier", [
+        ("single", "A==0.1.0"),
+        ("single-with-namespace", "foo::A==0.1.0")
+    ],
+    ids=["single", "single-with-namespace"],
+    indirect=["packages"]
+)
+def test_graph_link_weight(
+    mocked_resolver, mocked_package_extract, packages, identifier
+):
+    """Retrieve link weights within a simple graph."""
+    # Set requirements and expected package extraction for test.
+    requirements = [Requirement("A")]
+    mocked_package_extract.side_effect = [[packages[identifier]]]
+
+    # Create graph.
+    graph = wiz.graph.Graph(mocked_resolver)
+    graph.update_from_requirements(requirements)
+
+    assert graph.link_weight(identifier, "root") == 1
+
+    with pytest.raises(ValueError) as error:
+        graph.link_weight(identifier, "whatever")
+    assert "No link recorded for node: 'whatever'" in str(error)
+
+    with pytest.raises(ValueError) as error:
+        graph.link_weight("whatever", "root")
+    assert "No link recorded for node: 'whatever'" in str(error)
+
+
+@pytest.mark.parametrize("packages", ["many"], indirect=True)
+def test_graph_outcoming(mocked_resolver, mocked_package_extract, packages):
+    """Retrieve outcoming of nodes within a simple graph."""
+    # Set requirements and expected package extraction for test.
+    requirements = [Requirement("A==0.1.0")]
+    mocked_package_extract.side_effect = [
+        [packages["A==0.1.0"]], [packages["B==1.2.3"]], [packages["C"]],
+        [packages["D==4.1.0"]]
+    ]
+
+    # Create graph.
+    graph = wiz.graph.Graph(mocked_resolver)
+    graph.update_from_requirements(requirements)
+
+    assert graph.outcoming("A==0.1.0") == ["B==1.2.3"]
+    assert graph.outcoming("B==1.2.3") == ["C", "D==4.1.0"]
+    assert graph.outcoming("C") == []
+    assert graph.outcoming("D==4.1.0") == []
+    assert graph.outcoming("whatever") == []
+
+
+@pytest.mark.parametrize("packages", ["single"], indirect=True)
+def test_graph_find(mocked_resolver, mocked_package_extract, packages):
+    """Find nodes from requirement."""
+    # Set requirements and expected package extraction for test.
+    requirements = [Requirement("A")]
+    mocked_package_extract.side_effect = [[packages["A==0.1.0"]]]
+
+    # Create graph.
+    graph = wiz.graph.Graph(mocked_resolver)
+    graph.update_from_requirements(requirements)
+
+    assert graph.find(Requirement("A")) == {"A==0.1.0"}
+    assert graph.find(Requirement("::A < 3")) == {"A==0.1.0"}
+    assert graph.find(Requirement("A > 99")) == set()
+    assert graph.find(Requirement("foo::A")) == set()
+    assert graph.find(Requirement("A[V1]")) == set()
+
+
+@pytest.mark.parametrize("packages", ["conflicting-variants"], indirect=True)
+def test_graph_find_with_variants(
+    mocked_resolver, mocked_package_extract, packages
+):
+    """Find nodes from requirement."""
+    # Set requirements and expected package extraction for test.
+    requirements = [Requirement("A"), Requirement("B")]
+    mocked_package_extract.side_effect = [
+        [packages["A[V3]"],  packages["A[V2]"], packages["A[V1]"]],
+        [packages["B[V2]==1.2.3"], packages["B[V1]==1.2.3"]], [packages["C"]],
+        [packages["C"]],
+    ]
+
+    # Create graph.
+    graph = wiz.graph.Graph(mocked_resolver)
+    graph.update_from_requirements(requirements)
+
+    assert graph.find(Requirement("A")) == {"A[V1]", "A[V2]", "A[V3]"}
+    assert graph.find(Requirement("A[V1]")) == {"A[V1]"}
+    assert graph.find(Requirement("B")) == {"B[V2]==1.2.3", "B[V1]==1.2.3"}
+    assert graph.find(Requirement("B>2")) == set()
+    assert graph.find(Requirement("B[V2]")) == {"B[V2]==1.2.3"}
+
+
+@pytest.mark.parametrize("packages", ["single"], indirect=True)
+def test_graph_update_from_requirements_single(
+    mocked_resolver, mocked_package_extract, packages
+):
+    """Create an graph with one request."""
+    # Set requirements and expected package extraction for test.
+    requirements = [Requirement("A")]
+    mocked_package_extract.side_effect = [[packages["A==0.1.0"]]]
+
+    # Create graph.
+    graph = wiz.graph.Graph(mocked_resolver)
+    graph.update_from_requirements(requirements)
+
+    # Check call to extract packages from requirement.
+    mocked_package_extract.assert_called_once_with(
+        Requirement("A"), mocked_resolver.definition_mapping,
+        namespace_counter=collections.Counter()
     )
 
+    # Check whether the graph has conflicts, conditions or/and errors.
+    assert graph.conflicting() == set()
+    assert graph.conflicting_variant_groups() == []
+    assert graph.conditioned_nodes() == []
+    assert graph.errors() == {}
+
+    # Check full data.
     assert graph.data() == {
-        "identifier": mocker.ANY,
         "node_mapping": {
-            "Foo::A==0.2.0": {
-                "package": {
-                    "identifier": "Foo::A==0.2.0",
-                    "namespace": "Foo",
-                    "version": "0.2.0"
-                },
-                "parents": ["root"]
-            },
-            "Foo::B==2.1.1": {
-                "package": {
-                    "identifier": "Foo::B==2.1.1",
-                    "namespace": "Foo",
-                    "version": "2.1.1"
-                },
-                "parents": ["root"]
-            }
+            "A==0.1.0": wiz.graph.Node(
+                packages["A==0.1.0"], parent_identifiers={"root"}
+            )
         },
         "link_mapping": {
             "root": {
-                "Foo::A==0.2.0": {
-                    "requirement": Requirement("Foo::A"), "weight": 1
-                },
-                "Foo::B==2.1.1": {
-                    "requirement": Requirement("Foo::B >=2"), "weight": 2
+                "A==0.1.0": {"requirement": Requirement("::A"), "weight": 1}
+            }
+        },
+        "error_mapping": {},
+        "conditioned_nodes": [],
+    }
+
+
+@pytest.mark.parametrize("packages", ["single"], indirect=True)
+def test_graph_update_from_requirements_single_detached(
+    mocked_resolver, mocked_package_extract, packages
+):
+    """Create an graph with one request detached from the root node."""
+    # Set requirements and expected package extraction for test.
+    requirements = [Requirement("A")]
+    mocked_package_extract.side_effect = [[packages["A==0.1.0"]]]
+
+    # Create graph.
+    graph = wiz.graph.Graph(mocked_resolver)
+    graph.update_from_requirements(requirements, detached=True)
+
+    # Check call to extract packages from requirement.
+    mocked_package_extract.assert_called_once_with(
+        Requirement("A"), mocked_resolver.definition_mapping,
+        namespace_counter=collections.Counter()
+    )
+
+    # Check whether the graph has conflicts, conditions or/and errors.
+    assert graph.conflicting() == set()
+    assert graph.conflicting_variant_groups() == []
+    assert graph.conditioned_nodes() == []
+    assert graph.errors() == {}
+
+    # Check full data.
+    assert graph.data() == {
+        "node_mapping": {
+            "A==0.1.0": wiz.graph.Node(
+                packages["A==0.1.0"], parent_identifiers={}
+            )
+        },
+        "link_mapping": {},
+        "error_mapping": {},
+        "conditioned_nodes": [],
+    }
+
+
+@pytest.mark.parametrize("packages", ["single-with-namespace"], indirect=True)
+def test_graph_update_from_requirements_single_with_namespace(
+    mocked_resolver, mocked_package_extract, packages
+):
+    """Create an graph with one request extracting a package with namespace."""
+    # Set requirements and expected package extraction for test.
+    requirements = [Requirement("A")]
+    mocked_package_extract.side_effect = [[packages["foo::A==0.1.0"]]]
+    mocked_resolver.definition_mapping["__namespace__"]["A"] = {"foo"}
+
+    # Create graph.
+    graph = wiz.graph.Graph(mocked_resolver)
+    graph.update_from_requirements(requirements)
+
+    # Check call to extract packages from requirement.
+    mocked_package_extract.assert_called_once_with(
+        Requirement("A"), mocked_resolver.definition_mapping,
+        namespace_counter=collections.Counter({"foo": 1})
+    )
+
+    # Check whether the graph has conflicts, conditions or/and errors.
+    assert graph.conflicting() == set()
+    assert graph.conflicting_variant_groups() == []
+    assert graph.conditioned_nodes() == []
+    assert graph.errors() == {}
+
+    # Check full data.
+    assert graph.data() == {
+        "node_mapping": {
+            "foo::A==0.1.0": wiz.graph.Node(
+                packages["foo::A==0.1.0"], parent_identifiers={"root"}
+            )
+        },
+        "link_mapping": {
+            "root": {
+                "foo::A==0.1.0": {
+                    "requirement": Requirement("foo::A"), "weight": 1
                 }
             }
         },
-        "identifiers_per_definition": {
-            "Foo::A": ["Foo::A==0.2.0"],
-            "Foo::B": ["Foo::B==2.1.1"]
-        },
-        "variants_per_definition": {},
+        "error_mapping": {},
         "conditioned_nodes": [],
-        "namespace_count": {"Bar": 1, "Foo": 2},
-        "error_mapping": {}
     }
 
 
-def test_graph_update_from_requirements_with_skipped_conditional_packages(
-    mocker, mocked_resolver, mocked_package_extract
+def test_graph_update_from_requirements_single_with_error(
+    mocked_resolver, mocked_package_extract
 ):
-    """Update graph from requirements with skipped conditional packages."""
+    """Create an graph with one request failing to extract package."""
+    mocked_package_extract.side_effect = wiz.exception.RequestNotFound("Error")
+
     graph = wiz.graph.Graph(mocked_resolver)
+    graph.update_from_requirements([Requirement("A")])
 
-    _mapping = {
-        "A==0.2.0": wiz.package.Package(
-            wiz.definition.Definition({
-                "identifier": "A",
-                "version": "0.2.0",
-            })
-        ),
-        "B==2.1.1": wiz.package.Package(
-            wiz.definition.Definition({
-                "identifier": "B",
-                "version": "2.1.1",
-                "conditions": ["C > 2"]
-            })
-        ),
-        "C==2.0.4": wiz.package.Package(
-            wiz.definition.Definition({
-                "identifier": "C",
-                "version": "2.0.4",
-            })
-        ),
-        "D==0.1.0": wiz.package.Package(
-            wiz.definition.Definition({
-                "identifier": "D",
-                "version": "0.1.0",
-                "conditions": ["W"]
-            })
-        ),
-    }
-
-    mocked_package_extract.side_effect = [
-        [_mapping["A==0.2.0"]],
-        [_mapping["B==2.1.1"]],
-        [_mapping["D==0.1.0"]],
-        # Extract conditional package
-        [_mapping["C==2.0.4"]],
-        wiz.exception.WizError("Oh Shit!")
-    ]
-
-    graph.update_from_requirements(
-        [Requirement("A"), Requirement("B>=2"), Requirement("D")], graph.ROOT
+    # Check call to extract packages from requirement.
+    mocked_package_extract.assert_called_once_with(
+        Requirement("A"), mocked_resolver.definition_mapping,
+        namespace_counter=collections.Counter()
     )
 
+    assert graph.nodes() == []
+    assert graph.conflicting() == set()
+    assert graph.conflicting_variant_groups() == []
+    assert graph.conditioned_nodes() == []
+    assert graph.errors() == {
+        "root": ["Error"]
+    }
+
+    # Check full data.
     assert graph.data() == {
-        "identifier": mocker.ANY,
-        "node_mapping": {
-            "A==0.2.0": {
-                "package": {
-                    "identifier": "A==0.2.0",
-                    "version": "0.2.0",
-                },
-                "parents": ["root"],
-            }
-        },
-        "link_mapping": {
-            "root": {
-                "A==0.2.0": {"requirement": Requirement("A"), "weight": 1}
-            }
-        },
-        "identifiers_per_definition": {
-            "A": ["A==0.2.0"]
-        },
-        "conditioned_nodes": [
-            {
-                "requirement": Requirement("B >=2"),
-                "package": {
-                    "identifier": "B==2.1.1",
-                    "version": "2.1.1",
-                    "conditions": ["C > 2"]
-                },
-                "parent_identifier": "root",
-                "weight": 2
-            },
-            {
-                "requirement": Requirement("D"),
-                "package": {
-                    "identifier": "D==0.1.0",
-                    "version": "0.1.0",
-                    "conditions": ["W"]
-                },
-                "parent_identifier": "root",
-                "weight": 3
-            }
-        ],
-        "variants_per_definition": {},
-        "namespace_count": {},
-        "error_mapping": {}
-    }
-
-
-def test_graph_update_from_requirements_with_used_conditional_packages(
-    mocker, mocked_resolver, mocked_package_extract
-):
-    """Update graph from requirements with used conditional packages."""
-    graph = wiz.graph.Graph(mocked_resolver)
-
-    _mapping = {
-        "A==0.2.0": wiz.package.Package(
-            wiz.definition.Definition({
-                "identifier": "A",
-                "version": "0.2.0"
-            })
-        ),
-        "B==2.1.1": wiz.package.Package(
-            wiz.definition.Definition({
-                "identifier": "B",
-                "version": "2.1.1",
-                "conditions": ["A"],
-            })
-        )
-    }
-
-    mocked_package_extract.side_effect = [
-        [_mapping["A==0.2.0"]],
-        [_mapping["B==2.1.1"]],
-        # Extract package from condition
-        [_mapping["A==0.2.0"]]
-    ]
-
-    graph.update_from_requirements(
-        [Requirement("A"), Requirement("B>=2")], graph.ROOT
-    )
-
-    assert graph.data() == {
-        "identifier": mocker.ANY,
-        "node_mapping": {
-            "A==0.2.0": {
-                "package": {
-                    "identifier": "A==0.2.0",
-                    "version": "0.2.0"
-                },
-                "parents": ["root"]
-            },
-            "B==2.1.1": {
-                "package": {
-                    "identifier": "B==2.1.1",
-                    "version": "2.1.1",
-                    "conditions": ["A"],
-                },
-                "parents": ["root"]
-            }
-        },
-        "link_mapping": {
-            "root": {
-                "A==0.2.0": {"requirement": Requirement("A"), "weight": 1},
-                "B==2.1.1": {"requirement": Requirement("B >=2"), "weight": 2}
-            }
-        },
-        "identifiers_per_definition": {
-            "A": ["A==0.2.0"],
-            "B": ["B==2.1.1"]
-        },
-        "conditioned_nodes": [
-            {
-                "requirement": Requirement("B >=2"),
-                "package": {
-                    "identifier": "B==2.1.1",
-                    "version": "2.1.1",
-                    "conditions": ["A"],
-                },
-                "parent_identifier": "root",
-                "weight": 2
-            },
-        ],
-        "variants_per_definition": {},
-        "namespace_count": {},
-        "error_mapping": {}
-    }
-
-
-def test_graph_update_from_requirements_with_errors(
-    mocker, mocked_resolver, mocked_package_extract
-):
-    """Update graph from requirements with errors."""
-    graph = wiz.graph.Graph(mocked_resolver)
-
-    _mapping = {
-        "A==0.2.0": wiz.package.Package(
-            wiz.definition.Definition({
-                "identifier": "A",
-                "version": "0.2.0"
-            })
-        ),
-        "B==2.1.1": wiz.package.Package(
-            wiz.definition.Definition({
-                "identifier": "B",
-                "version": "2.1.1",
-                "requirements": ["incorrect1", "incorrect2"]
-            })
-        )
-    }
-
-    mocked_package_extract.side_effect = [
-        [_mapping["A==0.2.0"]],
-        [_mapping["B==2.1.1"]],
-        wiz.exception.RequestNotFound("incorrect1"),
-        wiz.exception.RequestNotFound("incorrect2"),
-    ]
-
-    graph.update_from_requirements(
-        [Requirement("A"), Requirement("B>=2")], graph.ROOT
-    )
-
-    assert graph.data() == {
-        "identifier": mocker.ANY,
-        "node_mapping": {
-            "A==0.2.0": {
-                "package": {
-                    "identifier": "A==0.2.0",
-                    "version": "0.2.0"
-                },
-                "parents": ["root"]
-            },
-            "B==2.1.1": {
-                "package": {
-                    "identifier": "B==2.1.1",
-                    "version": "2.1.1",
-                    "requirements": ["incorrect1", "incorrect2"]
-                },
-                "parents": ["root"]
-            }
-        },
-        "link_mapping": {
-            "root": {
-                "A==0.2.0": {"requirement": Requirement("A"), "weight": 1},
-                "B==2.1.1": {"requirement": Requirement("B >=2"), "weight": 2}
-            }
-        },
-        "identifiers_per_definition": {
-            "A": ["A==0.2.0"],
-            "B": ["B==2.1.1"]
-        },
+        "node_mapping": {},
+        "link_mapping": {},
+        "error_mapping": {"root": ["Error"]},
         "conditioned_nodes": [],
-        "variants_per_definition": {},
-        "namespace_count": {},
-        "error_mapping": {
-            "B==2.1.1": ["incorrect1", "incorrect2"],
-        }
     }
 
 
-@pytest.mark.parametrize("options", [
-    {},
-    {"weight": 5},
-], ids=[
-    "simple",
-    "with-weight",
-])
-def test_graph_update_from_requirement_existing(
-    mocker, mocked_resolver, mocked_package_extract, mocked_queue, options
+@pytest.mark.parametrize("packages", ["many"], indirect=True)
+def test_graph_update_from_requirements_many(
+    mocker, mocked_resolver, mocked_package_extract, packages
 ):
-    """Update graph from requirement."""
-    package = wiz.package.Package(
-        wiz.definition.Definition({
-            "identifier": "A",
-            "version": "0.1.0"
-        })
-    )
-    node = mocker.Mock(identifier="_A==0.1.0")
-    requirement = Requirement("A")
+    """Create an graph with several requests leading to more requests."""
+    # Set requirements and expected package extraction for test.
+    requirements = [Requirement("A"), Requirement("D>3")]
+    mocked_package_extract.side_effect = [
+        [packages["A==0.1.0"]],  [packages["D==4.1.0"]], [packages["B==1.2.3"]],
+        [packages["C"]], [packages["D==4.1.0"]]
+    ]
 
-    mocked_package_extract.return_value = [package]
-
+    # Create graph.
     graph = wiz.graph.Graph(mocked_resolver)
-    graph.create_link = mocker.Mock()
-    graph._create_node_from_package = mocker.Mock()
-    graph._node_mapping = {"A==0.1.0": node}
-    graph.exists = mocker.Mock(return_value=True)
+    graph.update_from_requirements(requirements)
 
-    graph._update_from_requirement(
-        requirement, graph.ROOT, mocked_queue, **options
-    )
+    # Check call to extract packages from requirement.
+    assert mocked_package_extract.call_args_list == [
+        mocker.call(
+            Requirement("A"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        ),
+        mocker.call(
+            Requirement("D > 3"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        ),
+        mocker.call(
+            Requirement("B"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        ),
+        mocker.call(
+            Requirement("C"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        ),
+        mocker.call(
+            Requirement("D > 1"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        )
+    ]
 
-    graph._create_node_from_package.assert_not_called()
-    graph.create_link.assert_called_once_with(
-        "_A==0.1.0", graph.ROOT, requirement,
-        weight=options.get("weight", 1)
-    )
+    # Check whether the graph has conflicts, conditions or/and errors.
+    assert graph.conflicting() == set()
+    assert graph.conflicting_variant_groups() == []
+    assert graph.conditioned_nodes() == []
+    assert graph.errors() == {}
 
-    node.add_parent.assert_called_once_with(graph.ROOT)
+    # Check full data.
+    assert graph.data() == {
+        "node_mapping": {
+            "A==0.1.0": wiz.graph.Node(
+                packages["A==0.1.0"], parent_identifiers={"root"}
+            ),
+            "B==1.2.3": wiz.graph.Node(
+                packages["B==1.2.3"], parent_identifiers={"A==0.1.0"}
+            ),
+            "C": wiz.graph.Node(
+                packages["C"], parent_identifiers={"B==1.2.3"}
+            ),
+            "D==4.1.0": wiz.graph.Node(
+                packages["D==4.1.0"], parent_identifiers={"B==1.2.3", "root"}
+            ),
+        },
+        "link_mapping": {
+            "root": {
+                "A==0.1.0": {"requirement": Requirement("::A"), "weight": 1},
+                "D==4.1.0": {"requirement": Requirement("::D>3"), "weight": 2},
+            },
+            "A==0.1.0": {
+                "B==1.2.3": {"requirement": Requirement("::B"), "weight": 1}
+            },
+            "B==1.2.3": {
+                "C": {"requirement": Requirement("::C"), "weight": 1},
+                "D==4.1.0": {"requirement": Requirement("::D>1"), "weight": 2},
+            }
+        },
+        "error_mapping": {},
+        "conditioned_nodes": [],
+    }
 
-    mocked_queue.put.assert_not_called()
 
-
-@pytest.mark.parametrize("options", [
-    {},
-    {"weight": 5},
-], ids=[
-    "simple",
-    "with-weight",
-])
-def test_graph_update_from_requirement_non_existing(
-    mocker, mocked_resolver, mocked_package_extract, mocked_queue, options
+@pytest.mark.parametrize("packages", ["many"], indirect=True)
+def test_graph_update_from_requirements_many_detached(
+    mocker, mocked_resolver, mocked_package_extract, packages
 ):
-    """Update graph from requirement."""
-    package = wiz.package.Package(
-        wiz.definition.Definition({
-            "identifier": "A",
-            "version": "0.1.0"
-        })
-    )
-    node = mocker.Mock(identifier="_A==0.1.0")
-    requirement = Requirement("A")
+    """Create an graph with several requests detached from the root node."""
+    # Set requirements and expected package extraction for test.
+    requirements = [Requirement("A"), Requirement("D>3")]
+    mocked_package_extract.side_effect = [
+        [packages["A==0.1.0"]],  [packages["D==4.1.0"]], [packages["B==1.2.3"]],
+        [packages["C"]], [packages["D==4.1.0"]]
+    ]
 
-    mocked_package_extract.return_value = [package]
-
+    # Create graph.
     graph = wiz.graph.Graph(mocked_resolver)
-    graph.create_link = mocker.Mock()
-    graph._create_node_from_package = mocker.Mock()
-    graph._node_mapping = {"A==0.1.0": node}
-    graph.exists = mocker.Mock(return_value=False)
+    graph.update_from_requirements(requirements, detached=True)
 
-    graph._update_from_requirement(
-        requirement, graph.ROOT, mocked_queue, **options
-    )
+    # Check call to extract packages from requirement.
+    assert mocked_package_extract.call_args_list == [
+        mocker.call(
+            Requirement("A"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        ),
+        mocker.call(
+            Requirement("D > 3"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        ),
+        mocker.call(
+            Requirement("B"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        ),
+        mocker.call(
+            Requirement("C"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        ),
+        mocker.call(
+            Requirement("D > 1"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        )
+    ]
 
-    graph._create_node_from_package.assert_called_once_with(package)
-    graph.create_link.assert_called_once_with(
-        "_A==0.1.0",
-        graph.ROOT,
-        requirement,
-        weight=options.get("weight", 1)
-    )
+    # Check whether the graph has conflicts, conditions or/and errors.
+    assert graph.conflicting() == set()
+    assert graph.conflicting_variant_groups() == []
+    assert graph.conditioned_nodes() == []
+    assert graph.errors() == {}
 
-    node.add_parent.assert_called_once_with(graph.ROOT)
+    # Check full data.
+    assert graph.data() == {
+        "node_mapping": {
+            "A==0.1.0": wiz.graph.Node(
+                packages["A==0.1.0"], parent_identifiers={}
+            ),
+            "B==1.2.3": wiz.graph.Node(
+                packages["B==1.2.3"], parent_identifiers={"A==0.1.0"}
+            ),
+            "C": wiz.graph.Node(
+                packages["C"], parent_identifiers={"B==1.2.3"}
+            ),
+            "D==4.1.0": wiz.graph.Node(
+                packages["D==4.1.0"], parent_identifiers={"B==1.2.3"}
+            ),
+        },
+        "link_mapping": {
+            "A==0.1.0": {
+                "B==1.2.3": {"requirement": Requirement("::B"), "weight": 1}
+            },
+            "B==1.2.3": {
+                "C": {"requirement": Requirement("::C"), "weight": 1},
+                "D==4.1.0": {"requirement": Requirement("::D>1"), "weight": 2},
+            }
+        },
+        "error_mapping": {},
+        "conditioned_nodes": [],
+    }
 
-    mocked_queue.put.assert_not_called()
 
-
-@pytest.mark.parametrize("options", [
-    {},
-    {"weight": 5},
-], ids=[
-    "simple",
-    "with-weight",
-])
-def test_graph_update_from_requirement_non_existing_with_requirements(
-    mocker, mocked_resolver, mocked_package_extract, mocked_queue, options
+@pytest.mark.parametrize("packages", ["many-with-namespaces"], indirect=True)
+def test_graph_update_from_requirements_many_with_namespaces(
+    mocker, mocked_resolver, mocked_package_extract, packages
 ):
-    """Update graph from requirement."""
-    package = wiz.package.Package(
-        wiz.definition.Definition({
-            "identifier": "A",
-            "version": "0.1.0",
-            "requirements": ["B", "C", "D"]
-        })
-    )
-    node = mocker.Mock(identifier="_A==0.1.0")
-    requirement = Requirement("A")
+    """Create an graph with several requests leading to more requests."""
+    # Set requirements and expected package extraction for test.
+    requirements = [Requirement("foo::A"), Requirement("D>3")]
+    mocked_package_extract.side_effect = [
+        [packages["foo::A==0.1.0"]],  [packages["D==4.1.0"]],
+        [packages["bar::B==1.2.3"]], [packages["foo::C"]],
+        [packages["D==4.1.0"]]
+    ]
 
-    mocked_package_extract.return_value = [package]
-
+    # Create graph.
     graph = wiz.graph.Graph(mocked_resolver)
-    graph.create_link = mocker.Mock()
-    graph._create_node_from_package = mocker.Mock()
-    graph._node_mapping = {"A==0.1.0": node}
-    graph.exists = mocker.Mock(return_value=False)
+    graph.update_from_requirements(requirements)
 
-    graph._update_from_requirement(
-        requirement, graph.ROOT, mocked_queue, **options
-    )
+    # Check call to extract packages from requirement.
+    assert mocked_package_extract.call_args_list == [
+        mocker.call(
+            Requirement("foo::A"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter({"foo": 1})
+        ),
+        mocker.call(
+            Requirement("D > 3"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter({"foo": 1})
+        ),
+        mocker.call(
+            Requirement("bar::B"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter({"foo": 1})
+        ),
+        mocker.call(
+            Requirement("foo::C"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter({"foo": 1})
+        ),
+        mocker.call(
+            Requirement("D > 1"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter({"foo": 1})
+        )
+    ]
 
-    graph._create_node_from_package.assert_called_once_with(package)
-    graph.create_link.assert_called_once_with(
-        "_A==0.1.0",
-        graph.ROOT,
-        requirement,
-        weight=options.get("weight", 1)
-    )
+    # Check whether the graph has conflicts, conditions or/and errors.
+    assert graph.conflicting() == set()
+    assert graph.conflicting_variant_groups() == []
+    assert graph.conditioned_nodes() == []
+    assert graph.errors() == {}
 
-    node.add_parent.assert_called_once_with(graph.ROOT)
+    # Check full data.
+    assert graph.data() == {
+        "node_mapping": {
+            "foo::A==0.1.0": wiz.graph.Node(
+                packages["foo::A==0.1.0"], parent_identifiers={"root"}
+            ),
+            "bar::B==1.2.3": wiz.graph.Node(
+                packages["bar::B==1.2.3"], parent_identifiers={"foo::A==0.1.0"}
+            ),
+            "foo::C": wiz.graph.Node(
+                packages["foo::C"], parent_identifiers={"bar::B==1.2.3"}
+            ),
+            "D==4.1.0": wiz.graph.Node(
+                packages["D==4.1.0"],
+                parent_identifiers={"bar::B==1.2.3", "root"}
+            ),
+        },
+        "link_mapping": {
+            "root": {
+                "foo::A==0.1.0": {
+                    "requirement": Requirement("foo::A"), "weight": 1
+                },
+                "D==4.1.0": {"requirement": Requirement("::D>3"), "weight": 2},
+            },
+            "foo::A==0.1.0": {
+                "bar::B==1.2.3": {
+                    "requirement": Requirement("bar::B"), "weight": 1
+                }
+            },
+            "bar::B==1.2.3": {
+                "foo::C": {"requirement": Requirement("foo::C"), "weight": 1},
+                "D==4.1.0": {"requirement": Requirement("::D>1"), "weight": 2},
+            }
+        },
+        "error_mapping": {},
+        "conditioned_nodes": [],
+    }
 
-    assert mocked_queue.put.call_count == 3
-    mocked_queue.put.assert_any_call({
-        "requirement": Requirement("B"),
-        "parent_identifier": "A==0.1.0",
-        "weight": 1
-    })
-    mocked_queue.put.assert_any_call({
-        "requirement": Requirement("C"),
-        "parent_identifier": "A==0.1.0",
-        "weight": 2
-    })
-    mocked_queue.put.assert_any_call({
-        "requirement": Requirement("D"),
-        "parent_identifier": "A==0.1.0",
-        "weight": 3
-    })
 
-
-@pytest.mark.parametrize("options", [
-    {},
-    {"weight": 5},
-], ids=[
-    "simple",
-    "with-weight",
-])
-def test_graph_update_from_requirement_multi_packages(
-    mocker, mocked_resolver, mocked_package_extract, mocked_queue, options
+@pytest.mark.parametrize("packages", ["many"], indirect=True)
+def test_graph_update_from_requirements_many_with_error(
+    mocker, mocked_resolver, mocked_package_extract, packages
 ):
-    """Update graph from requirement."""
-    definition = wiz.definition.Definition({
-        "identifier": "A",
-        "version": "0.1.0",
-        "variants": [
-            {"identifier": "variant1"},
-            {"identifier": "variant2"},
-            {"identifier": "variant3"},
+    """Create an graph with several requests and one of them is failing."""
+    # Set requirements and expected package extraction for test.
+    requirements = [Requirement("A"), Requirement("C")]
+    mocked_package_extract.side_effect = [
+        [packages["A==0.1.0"]],  [packages["C"]], [packages["B==1.2.3"]],
+        [packages["C"]], wiz.exception.RequestNotFound("Error")
+    ]
+
+    # Create graph.
+    graph = wiz.graph.Graph(mocked_resolver)
+    graph.update_from_requirements(requirements)
+
+    # Check call to extract packages from requirement.
+    assert mocked_package_extract.call_args_list == [
+        mocker.call(
+            Requirement("A"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        ),
+        mocker.call(
+            Requirement("C"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        ),
+        mocker.call(
+            Requirement("B"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        ),
+        mocker.call(
+            Requirement("C"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        ),
+        mocker.call(
+            Requirement("D > 1"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        )
+    ]
+
+    # Check whether the graph has conflicts, conditions or/and errors.
+    assert graph.conflicting() == set()
+    assert graph.conflicting_variant_groups() == []
+    assert graph.conditioned_nodes() == []
+    assert graph.errors() == {"B==1.2.3": ["Error"]}
+
+    # Check full data.
+    assert graph.data() == {
+        "node_mapping": {
+            "A==0.1.0": wiz.graph.Node(
+                packages["A==0.1.0"], parent_identifiers={"root"}
+            ),
+            "B==1.2.3": wiz.graph.Node(
+                packages["B==1.2.3"], parent_identifiers={"A==0.1.0"}
+            ),
+            "C": wiz.graph.Node(
+                packages["C"], parent_identifiers={"B==1.2.3", "root"}
+            )
+        },
+        "link_mapping": {
+            "root": {
+                "A==0.1.0": {"requirement": Requirement("::A"), "weight": 1},
+                "C": {"requirement": Requirement("::C"), "weight": 2},
+            },
+            "A==0.1.0": {
+                "B==1.2.3": {"requirement": Requirement("::B"), "weight": 1}
+            },
+            "B==1.2.3": {
+                "C": {"requirement": Requirement("::C"), "weight": 1},
+            }
+        },
+        "error_mapping": {"B==1.2.3": ["Error"]},
+        "conditioned_nodes": [],
+    }
+
+
+@pytest.mark.parametrize("packages", ["conflicting-versions"], indirect=True)
+def test_graph_update_from_requirements_several_times(
+    mocker, mocked_resolver, mocked_package_extract, packages
+):
+    """Create an graph with several requests several times."""
+    # Set requirements and expected package extraction for test.
+    mocked_package_extract.side_effect = [
+        [packages["A==0.1.0"]], [packages["B==1.2.3"]],
+        [packages["C"]], [packages["D==3.2.0"]], [packages["D==4.1.0"]],
+    ]
+
+    # Create graph.
+    graph = wiz.graph.Graph(mocked_resolver)
+    graph.update_from_requirements([Requirement("A")])
+    graph.update_from_requirements([Requirement("D>4")])
+
+    # Check call to extract packages from requirement.
+    assert mocked_package_extract.call_args_list == [
+        mocker.call(
+            Requirement("A"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        ),
+        mocker.call(
+            Requirement("B"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        ),
+        mocker.call(
+            Requirement("C"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        ),
+        mocker.call(
+            Requirement("D >= 3, <4"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        ),
+        mocker.call(
+            Requirement("D > 4"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        ),
+    ]
+
+    # Check whether the graph has conflicts, conditions or/and errors.
+    assert graph.conflicting() == {"D==4.1.0", "D==3.2.0"}
+    assert graph.conflicting_variant_groups() == []
+    assert graph.conditioned_nodes() == []
+    assert graph.errors() == {}
+
+    # Check full data.
+    assert graph.data() == {
+        "node_mapping": {
+            "A==0.1.0": wiz.graph.Node(
+                packages["A==0.1.0"], parent_identifiers={"root"}
+            ),
+            "B==1.2.3": wiz.graph.Node(
+                packages["B==1.2.3"], parent_identifiers={"A==0.1.0"}
+            ),
+            "C": wiz.graph.Node(
+                packages["C"], parent_identifiers={"B==1.2.3"}
+            ),
+            "D==3.2.0": wiz.graph.Node(
+                packages["D==3.2.0"], parent_identifiers={"B==1.2.3"}
+            ),
+            "D==4.1.0": wiz.graph.Node(
+                packages["D==4.1.0"], parent_identifiers={"root"}
+            ),
+        },
+        "link_mapping": {
+            "root": {
+                "A==0.1.0": {"requirement": Requirement("::A"), "weight": 1},
+                "D==4.1.0": {"requirement": Requirement("::D>4"), "weight": 2},
+            },
+            "A==0.1.0": {
+                "B==1.2.3": {"requirement": Requirement("::B"), "weight": 1}
+            },
+            "B==1.2.3": {
+                "C": {"requirement": Requirement("::C"), "weight": 1},
+                "D==3.2.0": {
+                    "requirement": Requirement("::D>=3,<4"), "weight": 2
+                },
+            }
+        },
+        "error_mapping": {},
+        "conditioned_nodes": [],
+    }
+
+
+@pytest.mark.parametrize("packages", ["many"], indirect=True)
+def test_graph_update_from_requirements_several_times_same(
+    mocker, mocked_resolver, mocked_package_extract, packages
+):
+    """Create an graph with same requests several times."""
+    # Set requirements and expected package extraction for test.
+    mocked_package_extract.side_effect = [
+        [packages["A==0.1.0"]], [packages["B==1.2.3"]],
+        [packages["C"]], [packages["D==4.1.0"]], [packages["A==0.1.0"]],
+    ]
+
+    # Create graph.
+    graph = wiz.graph.Graph(mocked_resolver)
+    graph.update_from_requirements([Requirement("A")])
+    graph.update_from_requirements([Requirement("A")])
+
+    # Check call to extract packages from requirement.
+    assert mocked_package_extract.call_args_list == [
+        mocker.call(
+            Requirement("A"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        ),
+        mocker.call(
+            Requirement("B"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        ),
+        mocker.call(
+            Requirement("C"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        ),
+        mocker.call(
+            Requirement("D>1"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        ),
+        mocker.call(
+            Requirement("A"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        ),
+    ]
+
+    # Check whether the graph has conflicts, conditions or/and errors.
+    assert graph.conflicting() == set()
+    assert graph.conflicting_variant_groups() == []
+    assert graph.conditioned_nodes() == []
+    assert graph.errors() == {}
+
+    # Check full data.
+    assert graph.data() == {
+        "node_mapping": {
+            "A==0.1.0": wiz.graph.Node(
+                packages["A==0.1.0"], parent_identifiers={"root"}
+            ),
+            "B==1.2.3": wiz.graph.Node(
+                packages["B==1.2.3"], parent_identifiers={"A==0.1.0"}
+            ),
+            "C": wiz.graph.Node(
+                packages["C"], parent_identifiers={"B==1.2.3"}
+            ),
+            "D==4.1.0": wiz.graph.Node(
+                packages["D==4.1.0"], parent_identifiers={"B==1.2.3"}
+            ),
+        },
+        "link_mapping": {
+            "root": {
+                "A==0.1.0": {"requirement": Requirement("::A"), "weight": 1},
+            },
+            "A==0.1.0": {
+                "B==1.2.3": {"requirement": Requirement("::B"), "weight": 1}
+            },
+            "B==1.2.3": {
+                "C": {"requirement": Requirement("::C"), "weight": 1},
+                "D==4.1.0": {"requirement": Requirement("::D>1"), "weight": 2},
+            }
+        },
+        "error_mapping": {},
+        "conditioned_nodes": [],
+    }
+
+
+@pytest.mark.parametrize("packages", ["many"], indirect=True)
+def test_graph_update_from_requirements_several_times_different_parent(
+    mocker, mocked_resolver, mocked_package_extract, packages
+):
+    """Create an graph with same requests several times with different parent.
+    """
+    # Set requirements and expected package extraction for test.
+    mocked_package_extract.side_effect = [
+        [packages["A==0.1.0"]], [packages["B==1.2.3"]],
+        [packages["C"]], [packages["D==4.1.0"]], [packages["A==0.1.0"]],
+        [packages["A==0.1.0"]],
+    ]
+
+    # Create graph.
+    graph = wiz.graph.Graph(mocked_resolver)
+    graph.update_from_requirements([Requirement("A")], detached=True)
+    graph.update_from_requirements([Requirement("A")])
+    graph.update_from_requirements([Requirement("A")], detached=True)
+
+    # Check call to extract packages from requirement.
+    assert mocked_package_extract.call_args_list == [
+        mocker.call(
+            Requirement("A"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        ),
+        mocker.call(
+            Requirement("B"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        ),
+        mocker.call(
+            Requirement("C"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        ),
+        mocker.call(
+            Requirement("D>1"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        ),
+        mocker.call(
+            Requirement("A"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        ),
+        mocker.call(
+            Requirement("A"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        ),
+    ]
+
+    # Check whether the graph has conflicts, conditions or/and errors.
+    assert graph.conflicting() == set()
+    assert graph.conflicting_variant_groups() == []
+    assert graph.conditioned_nodes() == []
+    assert graph.errors() == {}
+
+    # Check full data.
+    assert graph.data() == {
+        "node_mapping": {
+            "A==0.1.0": wiz.graph.Node(
+                packages["A==0.1.0"], parent_identifiers={"root"}
+            ),
+            "B==1.2.3": wiz.graph.Node(
+                packages["B==1.2.3"], parent_identifiers={"A==0.1.0"}
+            ),
+            "C": wiz.graph.Node(
+                packages["C"], parent_identifiers={"B==1.2.3"}
+            ),
+            "D==4.1.0": wiz.graph.Node(
+                packages["D==4.1.0"], parent_identifiers={"B==1.2.3"}
+            ),
+        },
+        "link_mapping": {
+            "root": {
+                "A==0.1.0": {"requirement": Requirement("::A"), "weight": 1},
+            },
+            "A==0.1.0": {
+                "B==1.2.3": {"requirement": Requirement("::B"), "weight": 1}
+            },
+            "B==1.2.3": {
+                "C": {"requirement": Requirement("::C"), "weight": 1},
+                "D==4.1.0": {"requirement": Requirement("::D>1"), "weight": 2},
+            }
+        },
+        "error_mapping": {},
+        "conditioned_nodes": [],
+    }
+
+
+@pytest.mark.parametrize("packages", ["many-with-conditions"], indirect=True)
+def test_graph_update_from_requirements_unfulfilled_conditions(
+    mocker, mocked_resolver, mocked_package_extract, packages
+):
+    """Create an graph with several unfulfilled conditions."""
+    # Set requirements and expected package extraction for test.
+    requirements = [Requirement("A"), Requirement("G"), Requirement("H")]
+    mocked_package_extract.side_effect = [
+        [packages["A==0.1.0"]],  [packages["G"]], [packages["H"]],
+        [packages["E"]], [packages["F==13"]], [packages["D==4.1.0"]],
+        wiz.exception.RequestNotFound("Error")
+    ]
+
+    # Create graph.
+    graph = wiz.graph.Graph(mocked_resolver)
+    graph.update_from_requirements(requirements)
+
+    # Check call to extract packages from requirement.
+    assert mocked_package_extract.call_args_list == [
+        mocker.call(
+            Requirement("A"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        ),
+        mocker.call(
+            Requirement("G"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        ),
+        mocker.call(
+            Requirement("H"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        ),
+        mocker.call(
+            Requirement("E"), mocked_resolver.definition_mapping,
+        ),
+        mocker.call(
+            Requirement("F"), mocked_resolver.definition_mapping,
+        ),
+        mocker.call(
+            Requirement("D"), mocked_resolver.definition_mapping,
+        ),
+        mocker.call(
+            Requirement("incorrect"), mocked_resolver.definition_mapping,
+        )
+    ]
+
+    # Check that conditions are recorded.
+    stored_nodes = [
+        wiz.graph.StoredNode(
+            requirement=Requirement("::A"),
+            package=packages["A==0.1.0"],
+            parent_identifier="root",
+            weight=1
+        ),
+        wiz.graph.StoredNode(
+            requirement=Requirement("::G"),
+            package=packages["G"],
+            parent_identifier="root",
+            weight=2
+        ),
+        wiz.graph.StoredNode(
+            requirement=Requirement("::H"),
+            package=packages["H"],
+            parent_identifier="root",
+            weight=3
+        )
+    ]
+    assert graph.conditioned_nodes() == stored_nodes
+
+    # Check whether the graph has conflicts, or/and errors.
+    assert graph.conflicting() == set()
+    assert graph.conflicting_variant_groups() == []
+    assert graph.errors() == {}
+
+    # Check full data.
+    assert graph.data() == {
+        "node_mapping": {},
+        "link_mapping": {},
+        "error_mapping": {},
+        "conditioned_nodes": stored_nodes
+    }
+
+
+@pytest.mark.parametrize("packages", ["many-with-conditions"], indirect=True)
+def test_graph_update_from_requirements_fulfilled_conditions(
+    mocker, mocked_resolver, mocked_package_extract, packages
+):
+    """Create an graph with several fulfilled conditions."""
+    # Set requirements and expected package extraction for test.
+    requirements = [
+        Requirement("A"), Requirement("G"), Requirement("H"), Requirement("E")
+    ]
+    mocked_package_extract.side_effect = [
+        # Extract required packages.
+        [packages["A==0.1.0"]],  [packages["G"]], [packages["H"]],
+        [packages["E"]], [packages["F==13"]],
+
+        # Check remaining conditions.
+        [packages["E"]], [packages["F==13"]], [packages["D==4.1.0"]],
+        wiz.exception.RequestNotFound("Error"),
+
+        # Conditions are fulfilled for A, adding it with dependencies.
+        [packages["B==1.2.3"]], [packages["C"]], [packages["D==4.1.0"]],
+
+        # Check remaining conditions.
+        [packages["F==13"]], [packages["D==4.1.0"]],
+        wiz.exception.RequestNotFound("Error"),
+
+        # Check remaining conditions.
+        wiz.exception.RequestNotFound("Error"),
+    ]
+
+    # Create graph.
+    graph = wiz.graph.Graph(mocked_resolver)
+    graph.update_from_requirements(requirements)
+
+    # Check call to extract packages from requirement.
+    assert mocked_package_extract.call_args_list == [
+        mocker.call(
+            Requirement("A"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        ),
+        mocker.call(
+            Requirement("G"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        ),
+        mocker.call(
+            Requirement("H"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        ),
+        mocker.call(
+            Requirement("E"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        ),
+        mocker.call(
+            Requirement("F"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        ),
+        mocker.call(
+            Requirement("E"), mocked_resolver.definition_mapping,
+        ),
+        mocker.call(
+            Requirement("F"), mocked_resolver.definition_mapping,
+        ),
+        mocker.call(
+            Requirement("D"), mocked_resolver.definition_mapping,
+        ),
+        mocker.call(
+            Requirement("incorrect"), mocked_resolver.definition_mapping,
+        ),
+        mocker.call(
+            Requirement("B"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        ),
+        mocker.call(
+            Requirement("C"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        ),
+        mocker.call(
+            Requirement("D>1"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        ),
+        mocker.call(
+            Requirement("F"), mocked_resolver.definition_mapping,
+        ),
+        mocker.call(
+            Requirement("D"), mocked_resolver.definition_mapping,
+        ),
+        mocker.call(
+            Requirement("incorrect"), mocked_resolver.definition_mapping,
+        ),
+        mocker.call(
+            Requirement("incorrect"), mocked_resolver.definition_mapping,
+        )
+    ]
+
+    # Check that conditions are recorded.
+    stored_nodes = [
+        wiz.graph.StoredNode(
+            requirement=Requirement("::A"),
+            package=packages["A==0.1.0"],
+            parent_identifier="root",
+            weight=1
+        ),
+        wiz.graph.StoredNode(
+            requirement=Requirement("::G"),
+            package=packages["G"],
+            parent_identifier="root",
+            weight=2
+        ),
+        wiz.graph.StoredNode(
+            requirement=Requirement("::H"),
+            package=packages["H"],
+            parent_identifier="root",
+            weight=3
+        )
+    ]
+    assert graph.conditioned_nodes() == stored_nodes
+
+    # Check whether the graph has conflicts, or/and errors.
+    assert graph.conflicting() == set()
+    assert graph.conflicting_variant_groups() == []
+    assert graph.errors() == {}
+
+    # Check full data.
+    assert graph.data() == {
+        "node_mapping": {
+            "A==0.1.0": wiz.graph.Node(
+                packages["A==0.1.0"], parent_identifiers={"root"}
+            ),
+            "B==1.2.3": wiz.graph.Node(
+                packages["B==1.2.3"], parent_identifiers={"A==0.1.0"}
+            ),
+            "C": wiz.graph.Node(
+                packages["C"], parent_identifiers={"B==1.2.3"}
+            ),
+            "D==4.1.0": wiz.graph.Node(
+                packages["D==4.1.0"], parent_identifiers={"B==1.2.3"}
+            ),
+            "E": wiz.graph.Node(
+                packages["E"], parent_identifiers={"root"}
+            ),
+            "F==13": wiz.graph.Node(
+                packages["F==13"], parent_identifiers={"E"}
+            ),
+            "G": wiz.graph.Node(
+                packages["G"], parent_identifiers={"root"}
+            ),
+        },
+        "link_mapping": {
+            "root": {
+                "A==0.1.0": {"requirement": Requirement("::A"), "weight": 1},
+                "G": {"requirement": Requirement("::G"), "weight": 2},
+                "E": {"requirement": Requirement("::E"), "weight": 4},
+            },
+            "A==0.1.0": {
+                "B==1.2.3": {"requirement": Requirement("::B"), "weight": 1}
+            },
+            "B==1.2.3": {
+                "C": {"requirement": Requirement("::C"), "weight": 1},
+                "D==4.1.0": {"requirement": Requirement("::D>1"), "weight": 2},
+            },
+            "E": {
+                "F==13": {"requirement": Requirement("::F"), "weight": 1}
+            },
+
+        },
+        "error_mapping": {},
+        "conditioned_nodes": stored_nodes
+    }
+
+
+@pytest.mark.parametrize("packages", ["conflicting-versions"], indirect=True)
+def test_graph_update_from_requirements_with_version_conflicts(
+    mocker, mocked_resolver, mocked_package_extract, packages
+):
+    """Create an graph with conflicting package version."""
+    # Set requirements and expected package extraction for test.
+    requirements = [Requirement("A"), Requirement("D")]
+    mocked_package_extract.side_effect = [
+        [packages["A==0.1.0"]],  [packages["D==4.1.0"]], [packages["B==1.2.3"]],
+        [packages["C"]], [packages["D==3.2.0"]],
+    ]
+
+    # Create graph.
+    graph = wiz.graph.Graph(mocked_resolver)
+    graph.update_from_requirements(requirements)
+
+    # Check call to extract packages from requirement.
+    assert mocked_package_extract.call_args_list == [
+        mocker.call(
+            Requirement("A"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        ),
+        mocker.call(
+            Requirement("D"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        ),
+        mocker.call(
+            Requirement("B"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        ),
+        mocker.call(
+            Requirement("C"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        ),
+        mocker.call(
+            Requirement("D >= 3, <4"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        )
+    ]
+
+    # Check whether the graph has conflicts, conditions or/and errors.
+    assert graph.conflicting() == {"D==4.1.0", "D==3.2.0"}
+    assert graph.conflicting_variant_groups() == []
+    assert graph.conditioned_nodes() == []
+    assert graph.errors() == {}
+
+    # Check full data.
+    assert graph.data() == {
+        "node_mapping": {
+            "A==0.1.0": wiz.graph.Node(
+                packages["A==0.1.0"], parent_identifiers={"root"}
+            ),
+            "B==1.2.3": wiz.graph.Node(
+                packages["B==1.2.3"], parent_identifiers={"A==0.1.0"}
+            ),
+            "C": wiz.graph.Node(
+                packages["C"], parent_identifiers={"B==1.2.3"}
+            ),
+            "D==3.2.0": wiz.graph.Node(
+                packages["D==3.2.0"], parent_identifiers={"B==1.2.3"}
+            ),
+            "D==4.1.0": wiz.graph.Node(
+                packages["D==4.1.0"], parent_identifiers={"root"}
+            )
+        },
+        "link_mapping": {
+            "root": {
+                "A==0.1.0": {"requirement": Requirement("::A"), "weight": 1},
+                "D==4.1.0": {"requirement": Requirement("::D"), "weight": 2},
+            },
+            "A==0.1.0": {
+                "B==1.2.3": {"requirement": Requirement("::B"), "weight": 1}
+            },
+            "B==1.2.3": {
+                "C": {"requirement": Requirement("::C"), "weight": 1},
+                "D==3.2.0": {
+                    "requirement": Requirement("::D>=3,<4"), "weight": 2
+                },
+            },
+        },
+        "error_mapping": {},
+        "conditioned_nodes": [],
+    }
+
+
+@pytest.mark.parametrize("packages", ["conflicting-variants"], indirect=True)
+def test_graph_update_from_requirements_with_variant_conflicts(
+    mocker, mocked_resolver, mocked_package_extract, packages
+):
+    """Create an graph with conflicting package version."""
+    # Set requirements and expected package extraction for test.
+    requirements = [Requirement("A"), Requirement("B[V1]")]
+    mocked_package_extract.side_effect = [
+        [packages["A[V3]"],  packages["A[V2]"], packages["A[V1]"]],
+        [packages["B[V1]==1.2.3"]], [packages["C"]],
+    ]
+
+    # Create graph.
+    graph = wiz.graph.Graph(mocked_resolver)
+    graph.update_from_requirements(requirements)
+
+    # Check call to extract packages from requirement.
+    assert mocked_package_extract.call_args_list == [
+        mocker.call(
+            Requirement("A"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        ),
+        mocker.call(
+            Requirement("B[V1]"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        ),
+        mocker.call(
+            Requirement("C"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        ),
+    ]
+
+    # Check whether the graph has conflicts, conditions or/and errors.
+    assert graph.conflicting() == {"A[V3]", "A[V2]", "A[V1]"}
+    assert graph.conflicting_variant_groups() == [["A[V3]", "A[V2]", "A[V1]"]]
+    assert graph.conditioned_nodes() == []
+    assert graph.errors() == {}
+
+    # Check full data.
+    assert graph.data() == {
+        "node_mapping": {
+            "A[V3]": wiz.graph.Node(
+                packages["A[V3]"], parent_identifiers={"root"}
+            ),
+            "A[V2]": wiz.graph.Node(
+                packages["A[V2]"], parent_identifiers={"root"}
+            ),
+            "A[V1]": wiz.graph.Node(
+                packages["A[V1]"], parent_identifiers={"root"}
+            ),
+            "B[V1]==1.2.3": wiz.graph.Node(
+                packages["B[V1]==1.2.3"], parent_identifiers={"root"}
+            ),
+            "C": wiz.graph.Node(
+                packages["C"], parent_identifiers={"B[V1]==1.2.3"}
+            )
+        },
+        "link_mapping": {
+            "root": {
+                "A[V3]": {"requirement": Requirement("::A"), "weight": 1},
+                "A[V2]": {"requirement": Requirement("::A"), "weight": 1},
+                "A[V1]": {"requirement": Requirement("::A"), "weight": 1},
+                "B[V1]==1.2.3": {
+                    "requirement": Requirement("::B[V1]"), "weight": 2
+                },
+            },
+            "B[V1]==1.2.3": {
+                "C": {"requirement": Requirement("::C"), "weight": 1},
+            },
+        },
+        "error_mapping": {},
+        "conditioned_nodes": [],
+    }
+
+
+@pytest.mark.parametrize("packages", ["many"], indirect=True)
+def test_graph_update_from_package(
+    mocker, mocked_resolver, mocked_package_extract, packages
+):
+    """Create an graph from one package."""
+    # Set expected package extraction for test.
+    mocked_package_extract.side_effect = [
+        [packages["B==1.2.3"]], [packages["C"]], [packages["D==4.1.0"]],
+    ]
+
+    # Create graph.
+    graph = wiz.graph.Graph(mocked_resolver)
+    graph.update_from_package(packages["A==0.1.0"], Requirement("A"))
+
+    # Check call to extract packages from requirement.
+    assert mocked_package_extract.call_args_list == [
+        mocker.call(
+            Requirement("B"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        ),
+        mocker.call(
+            Requirement("C"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        ),
+        mocker.call(
+            Requirement("D>1"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        ),
+    ]
+
+    # Check whether the graph has conflicts, conditions or/and errors.
+    assert graph.conflicting() == set()
+    assert graph.conflicting_variant_groups() == []
+    assert graph.conditioned_nodes() == []
+    assert graph.errors() == {}
+
+    # Check full data.
+    assert graph.data() == {
+        "node_mapping": {
+            "A==0.1.0": wiz.graph.Node(
+                packages["A==0.1.0"], parent_identifiers={"root"}
+            ),
+            "B==1.2.3": wiz.graph.Node(
+                packages["B==1.2.3"], parent_identifiers={"A==0.1.0"}
+            ),
+            "C": wiz.graph.Node(
+                packages["C"], parent_identifiers={"B==1.2.3"}
+            ),
+            "D==4.1.0": wiz.graph.Node(
+                packages["D==4.1.0"], parent_identifiers={"B==1.2.3"}
+            )
+        },
+        "link_mapping": {
+            "root": {
+                "A==0.1.0": {"requirement": Requirement("::A"), "weight": 1},
+            },
+            "A==0.1.0": {
+                "B==1.2.3": {"requirement": Requirement("::B"), "weight": 1},
+            },
+            "B==1.2.3": {
+                "C": {"requirement": Requirement("::C"), "weight": 1},
+                "D==4.1.0": {"requirement": Requirement("::D>1"), "weight": 2},
+            }
+        },
+        "error_mapping": {},
+        "conditioned_nodes": [],
+    }
+
+
+@pytest.mark.parametrize("packages", ["many"], indirect=True)
+def test_graph_update_from_package_detached(
+    mocker, mocked_resolver, mocked_package_extract, packages
+):
+    """Create an graph from one package detached from the root node."""
+    # Set expected package extraction for test.
+    mocked_package_extract.side_effect = [
+        [packages["B==1.2.3"]], [packages["C"]], [packages["D==4.1.0"]],
+    ]
+
+    # Create graph.
+    graph = wiz.graph.Graph(mocked_resolver)
+    graph.update_from_package(
+        packages["A==0.1.0"], Requirement("A"), detached=True
+    )
+
+    # Check call to extract packages from requirement.
+    assert mocked_package_extract.call_args_list == [
+        mocker.call(
+            Requirement("B"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        ),
+        mocker.call(
+            Requirement("C"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        ),
+        mocker.call(
+            Requirement("D>1"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        ),
+    ]
+
+    # Check whether the graph has conflicts, conditions or/and errors.
+    assert graph.conflicting() == set()
+    assert graph.conflicting_variant_groups() == []
+    assert graph.conditioned_nodes() == []
+    assert graph.errors() == {}
+
+    # Check full data.
+    assert graph.data() == {
+        "node_mapping": {
+            "A==0.1.0": wiz.graph.Node(
+                packages["A==0.1.0"], parent_identifiers=set()
+            ),
+            "B==1.2.3": wiz.graph.Node(
+                packages["B==1.2.3"], parent_identifiers={"A==0.1.0"}
+            ),
+            "C": wiz.graph.Node(
+                packages["C"], parent_identifiers={"B==1.2.3"}
+            ),
+            "D==4.1.0": wiz.graph.Node(
+                packages["D==4.1.0"], parent_identifiers={"B==1.2.3"}
+            )
+        },
+        "link_mapping": {
+            "A==0.1.0": {
+                "B==1.2.3": {"requirement": Requirement("::B"), "weight": 1},
+            },
+            "B==1.2.3": {
+                "C": {"requirement": Requirement("::C"), "weight": 1},
+                "D==4.1.0": {"requirement": Requirement("::D>1"), "weight": 2},
+            }
+        },
+        "error_mapping": {},
+        "conditioned_nodes": [],
+    }
+
+
+@pytest.mark.parametrize("packages", ["conflicting-versions"], indirect=True)
+def test_graph_update_from_package_several_times(
+    mocker, mocked_resolver, mocked_package_extract, packages
+):
+    """Create an graph from packages several times."""
+    # Set expected package extraction for test.
+    mocked_package_extract.side_effect = [
+        [packages["B==1.2.3"]], [packages["C"]], [packages["D==3.2.0"]],
+        [packages["D==4.1.0"]],
+    ]
+
+    # Create graph.
+    graph = wiz.graph.Graph(mocked_resolver)
+    graph.update_from_package(packages["A==0.1.0"], Requirement("A"))
+    graph.update_from_package(packages["D==4.1.0"], Requirement("D"))
+
+    # Check call to extract packages from requirement.
+    assert mocked_package_extract.call_args_list == [
+        mocker.call(
+            Requirement("B"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        ),
+        mocker.call(
+            Requirement("C"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        ),
+        mocker.call(
+            Requirement("D >= 3, <4"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        ),
+    ]
+
+    # Check whether the graph has conflicts, conditions or/and errors.
+    assert graph.conflicting() == {"D==4.1.0", "D==3.2.0"}
+    assert graph.conflicting_variant_groups() == []
+    assert graph.conditioned_nodes() == []
+    assert graph.errors() == {}
+
+    # Check full data.
+    assert graph.data() == {
+        "node_mapping": {
+            "A==0.1.0": wiz.graph.Node(
+                packages["A==0.1.0"], parent_identifiers={"root"}
+            ),
+            "B==1.2.3": wiz.graph.Node(
+                packages["B==1.2.3"], parent_identifiers={"A==0.1.0"}
+            ),
+            "C": wiz.graph.Node(
+                packages["C"], parent_identifiers={"B==1.2.3"}
+            ),
+            "D==3.2.0": wiz.graph.Node(
+                packages["D==3.2.0"], parent_identifiers={"B==1.2.3"}
+            ),
+            "D==4.1.0": wiz.graph.Node(
+                packages["D==4.1.0"], parent_identifiers={"root"}
+            ),
+        },
+        "link_mapping": {
+            "root": {
+                "A==0.1.0": {"requirement": Requirement("::A"), "weight": 1},
+                "D==4.1.0": {"requirement": Requirement("::D"), "weight": 2},
+            },
+            "A==0.1.0": {
+                "B==1.2.3": {"requirement": Requirement("::B"), "weight": 1},
+            },
+            "B==1.2.3": {
+                "C": {"requirement": Requirement("::C"), "weight": 1},
+                "D==3.2.0": {
+                    "requirement": Requirement("::D>=3,<4"), "weight": 2
+                },
+            }
+        },
+        "error_mapping": {},
+        "conditioned_nodes": [],
+    }
+
+
+@pytest.mark.parametrize("packages", ["many"], indirect=True)
+def test_graph_update_from_package_several_times_same(
+    mocker, mocked_resolver, mocked_package_extract, packages
+):
+    """Create an graph from the same package several times."""
+    # Set expected package extraction for test.
+    mocked_package_extract.side_effect = [
+        [packages["B==1.2.3"]], [packages["C"]], [packages["D==4.1.0"]],
+    ]
+
+    # Create graph.
+    graph = wiz.graph.Graph(mocked_resolver)
+    graph.update_from_package(packages["A==0.1.0"], Requirement("A"))
+    graph.update_from_package(packages["A==0.1.0"], Requirement("A"))
+
+    # Check call to extract packages from requirement.
+    assert mocked_package_extract.call_args_list == [
+        mocker.call(
+            Requirement("B"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        ),
+        mocker.call(
+            Requirement("C"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        ),
+        mocker.call(
+            Requirement("D>1"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        ),
+    ]
+
+    # Check whether the graph has conflicts, conditions or/and errors.
+    assert graph.conflicting() == set()
+    assert graph.conflicting_variant_groups() == []
+    assert graph.conditioned_nodes() == []
+    assert graph.errors() == {}
+
+    # Check full data.
+    assert graph.data() == {
+        "node_mapping": {
+            "A==0.1.0": wiz.graph.Node(
+                packages["A==0.1.0"], parent_identifiers={"root"}
+            ),
+            "B==1.2.3": wiz.graph.Node(
+                packages["B==1.2.3"], parent_identifiers={"A==0.1.0"}
+            ),
+            "C": wiz.graph.Node(
+                packages["C"], parent_identifiers={"B==1.2.3"}
+            ),
+            "D==4.1.0": wiz.graph.Node(
+                packages["D==4.1.0"], parent_identifiers={"B==1.2.3"}
+            )
+        },
+        "link_mapping": {
+            "root": {
+                "A==0.1.0": {"requirement": Requirement("::A"), "weight": 1},
+            },
+            "A==0.1.0": {
+                "B==1.2.3": {"requirement": Requirement("::B"), "weight": 1},
+            },
+            "B==1.2.3": {
+                "C": {"requirement": Requirement("::C"), "weight": 1},
+                "D==4.1.0": {"requirement": Requirement("::D>1"), "weight": 2},
+            }
+        },
+        "error_mapping": {},
+        "conditioned_nodes": [],
+    }
+
+
+@pytest.mark.parametrize("packages", ["many"], indirect=True)
+def test_graph_update_from_package_several_times_different_requirement(
+    mocker, mocked_resolver, mocked_package_extract, packages
+):
+    """Create an graph from the same package several times with different
+    requirement.
+    """
+    # Set expected package extraction for test.
+    mocked_package_extract.side_effect = [
+        [packages["B==1.2.3"]], [packages["C"]], [packages["D==4.1.0"]],
+    ]
+
+    # Create graph.
+    graph = wiz.graph.Graph(mocked_resolver)
+    graph.update_from_package(packages["A==0.1.0"], Requirement("A"))
+    graph.update_from_package(packages["A==0.1.0"], Requirement("A<1"))
+
+    # Check call to extract packages from requirement.
+    assert mocked_package_extract.call_args_list == [
+        mocker.call(
+            Requirement("B"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        ),
+        mocker.call(
+            Requirement("C"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        ),
+        mocker.call(
+            Requirement("D>1"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        ),
+    ]
+
+    # Check whether the graph has conflicts, conditions or/and errors.
+    assert graph.conflicting() == set()
+    assert graph.conflicting_variant_groups() == []
+    assert graph.conditioned_nodes() == []
+    assert graph.errors() == {}
+
+    # Check full data.
+    assert graph.data() == {
+        "node_mapping": {
+            "A==0.1.0": wiz.graph.Node(
+                packages["A==0.1.0"], parent_identifiers={"root"}
+            ),
+            "B==1.2.3": wiz.graph.Node(
+                packages["B==1.2.3"], parent_identifiers={"A==0.1.0"}
+            ),
+            "C": wiz.graph.Node(
+                packages["C"], parent_identifiers={"B==1.2.3"}
+            ),
+            "D==4.1.0": wiz.graph.Node(
+                packages["D==4.1.0"], parent_identifiers={"B==1.2.3"}
+            )
+        },
+        "link_mapping": {
+            "root": {
+                "A==0.1.0": {"requirement": Requirement("::A<1"), "weight": 1},
+            },
+            "A==0.1.0": {
+                "B==1.2.3": {"requirement": Requirement("::B"), "weight": 1},
+            },
+            "B==1.2.3": {
+                "C": {"requirement": Requirement("::C"), "weight": 1},
+                "D==4.1.0": {"requirement": Requirement("::D>1"), "weight": 2},
+            }
+        },
+        "error_mapping": {},
+        "conditioned_nodes": [],
+    }
+
+
+@pytest.mark.parametrize("packages", ["many"], indirect=True)
+def test_graph_update_from_package_several_times_different_parent(
+    mocker, mocked_resolver, mocked_package_extract, packages
+):
+    """Create an graph from the same package several times with different
+    parent.
+    """
+    # Set expected package extraction for test.
+    mocked_package_extract.side_effect = [
+        [packages["B==1.2.3"]], [packages["C"]], [packages["D==4.1.0"]],
+    ]
+
+    # Create graph.
+    graph = wiz.graph.Graph(mocked_resolver)
+    graph.update_from_package(
+        packages["A==0.1.0"], Requirement("A"), detached=True
+    )
+    graph.update_from_package(packages["A==0.1.0"], Requirement("A"))
+
+    # Check call to extract packages from requirement.
+    assert mocked_package_extract.call_args_list == [
+        mocker.call(
+            Requirement("B"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        ),
+        mocker.call(
+            Requirement("C"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        ),
+        mocker.call(
+            Requirement("D>1"), mocked_resolver.definition_mapping,
+            namespace_counter=collections.Counter()
+        ),
+    ]
+
+    # Check whether the graph has conflicts, conditions or/and errors.
+    assert graph.conflicting() == set()
+    assert graph.conflicting_variant_groups() == []
+    assert graph.conditioned_nodes() == []
+    assert graph.errors() == {}
+
+    # Check full data.
+    assert graph.data() == {
+        "node_mapping": {
+            "A==0.1.0": wiz.graph.Node(
+                packages["A==0.1.0"], parent_identifiers={"root"}
+            ),
+            "B==1.2.3": wiz.graph.Node(
+                packages["B==1.2.3"], parent_identifiers={"A==0.1.0"}
+            ),
+            "C": wiz.graph.Node(
+                packages["C"], parent_identifiers={"B==1.2.3"}
+            ),
+            "D==4.1.0": wiz.graph.Node(
+                packages["D==4.1.0"], parent_identifiers={"B==1.2.3"}
+            )
+        },
+        "link_mapping": {
+            "root": {
+                "A==0.1.0": {"requirement": Requirement("::A"), "weight": 1},
+            },
+            "A==0.1.0": {
+                "B==1.2.3": {"requirement": Requirement("::B"), "weight": 1},
+            },
+            "B==1.2.3": {
+                "C": {"requirement": Requirement("::C"), "weight": 1},
+                "D==4.1.0": {"requirement": Requirement("::D>1"), "weight": 2},
+            }
+        },
+        "error_mapping": {},
+        "conditioned_nodes": [],
+    }
+
+
+@pytest.mark.parametrize("packages", ["single"], indirect=True)
+def test_graph_remove(mocked_resolver, mocked_package_extract, packages):
+    """Remove one node from graph."""
+    # Set requirements and expected package extraction for test.
+    requirements = [Requirement("A")]
+    mocked_package_extract.side_effect = [[packages["A==0.1.0"]]]
+
+    # Create graph.
+    graph = wiz.graph.Graph(mocked_resolver)
+    graph.update_from_requirements(requirements)
+    graph.remove_node("A==0.1.0")
+
+    # Check whether the graph has conflicts, conditions or/and errors.
+    assert graph.conflicting() == set()
+    assert graph.conflicting_variant_groups() == []
+    assert graph.conditioned_nodes() == []
+    assert graph.errors() == {}
+
+    # Check full data.
+    assert graph.data() == {
+        "node_mapping": {},
+        "link_mapping": {
+            "root": {
+                "A==0.1.0": {"requirement": Requirement("::A"), "weight": 1}
+            }
+        },
+        "error_mapping": {},
+        "conditioned_nodes": [],
+    }
+
+
+def test_graph_remove_error(mocked_resolver):
+    """Fail to remove one node from graph."""
+    graph = wiz.graph.Graph(mocked_resolver)
+
+    with pytest.raises(ValueError) as error:
+        graph.remove_node("A==0.1.0")
+
+    assert "Node can not be removed: A==0.1.0" in str(error)
+
+
+@pytest.mark.parametrize("packages", ["conflicting-versions"], indirect=True)
+def test_graph_relink_parents(
+    mocked_resolver, mocked_package_extract, packages
+):
+    """Relink parents after removing a node."""
+    requirements = [Requirement("A"), Requirement("D==3.1.0")]
+    mocked_package_extract.side_effect = [
+        [packages["A==0.1.0"]],  [packages["D==3.1.0"]], [packages["B==1.2.3"]],
+        [packages["C"]], [packages["D==3.2.0"]],
+    ]
+
+    # Create graph.
+    graph = wiz.graph.Graph(mocked_resolver)
+    graph.update_from_requirements(requirements)
+
+    # Remove a node.
+    node = graph.node("D==3.2.0")
+    graph.remove_node("D==3.2.0")
+
+    # Relink parent from removed node.
+    graph.relink_parents(node)
+
+    # Check whether the graph has conflicts, conditions or/and errors.
+    assert graph.conflicting() == set()
+    assert graph.conflicting_variant_groups() == []
+    assert graph.conditioned_nodes() == []
+    assert graph.errors() == {}
+
+    # Check full data.
+    assert graph.data() == {
+        "node_mapping": {
+            "A==0.1.0": wiz.graph.Node(
+                packages["A==0.1.0"], parent_identifiers={"root"}
+            ),
+            "B==1.2.3": wiz.graph.Node(
+                packages["B==1.2.3"], parent_identifiers={"A==0.1.0"}
+            ),
+            "C": wiz.graph.Node(
+                packages["C"], parent_identifiers={"B==1.2.3"}
+            ),
+            "D==3.1.0": wiz.graph.Node(
+                packages["D==3.1.0"], parent_identifiers={"B==1.2.3", "root"}
+            ),
+        },
+        "link_mapping": {
+            "root": {
+                "A==0.1.0": {"requirement": Requirement("::A"), "weight": 1},
+                "D==3.1.0": {
+                    "requirement": Requirement("::D ==3.1.0"), "weight": 2
+                }
+            },
+            "A==0.1.0": {
+                "B==1.2.3": {"requirement": Requirement("::B"), "weight": 1}
+            },
+            "B==1.2.3": {
+                "C": {"requirement": Requirement("::C"), "weight": 1},
+                "D==3.1.0": {
+                    "requirement": Requirement("::D >=3, <4"), "weight": 2
+                },
+                "D==3.2.0": {
+                    "requirement": Requirement("::D >=3, <4"), "weight": 2
+                },
+            },
+        },
+        "error_mapping": {},
+        "conditioned_nodes": [],
+    }
+
+
+@pytest.mark.parametrize("packages", ["conflicting-versions"], indirect=True)
+def test_graph_relink_parents_error(
+    mocked_resolver, mocked_package_extract, packages
+):
+    """Fail to relink parents after removing a node."""
+    requirements = [Requirement("A"), Requirement("D==3.1.0")]
+    mocked_package_extract.side_effect = [
+        [packages["A==0.1.0"]],  [packages["D==3.1.0"]], [packages["B==1.2.3"]],
+        [packages["C"]], [packages["D==3.2.0"]],
+    ]
+
+    # Create graph.
+    graph = wiz.graph.Graph(mocked_resolver)
+    graph.update_from_requirements(requirements)
+
+    # Remove a node.
+    node = graph.node("D==3.1.0")
+    graph.remove_node("D==3.1.0")
+
+    # Relink parent from removed node.
+    graph.relink_parents(node)
+
+    # Check whether the graph has conflicts, conditions or/and errors.
+    assert graph.conflicting() == set()
+    assert graph.conflicting_variant_groups() == []
+    assert graph.conditioned_nodes() == []
+    assert graph.errors() == {
+        "root": [
+            "Requirement '::D ==3.1.0' can not be satisfied once 'D==3.1.0' is "
+            "removed from the graph."
         ]
-    })
-
-    packages = [
-        wiz.package.Package(definition, variant_index=0),
-        wiz.package.Package(definition, variant_index=1),
-        wiz.package.Package(definition, variant_index=2)
-    ]
-
-    nodes = [
-        mocker.Mock(identifier="_A[variant1]==0.1.0"),
-        mocker.Mock(identifier="_A[variant2]==0.1.0"),
-        mocker.Mock(identifier="_A[variant3]==0.1.0"),
-    ]
-
-    requirement = Requirement("A")
-
-    mocked_package_extract.return_value = packages
-
-    graph = wiz.graph.Graph(mocked_resolver)
-    graph.create_link = mocker.Mock()
-    graph._create_node_from_package = mocker.Mock()
-    graph._node_mapping = {
-        "A[variant1]==0.1.0": nodes[0],
-        "A[variant2]==0.1.0": nodes[1],
-        "A[variant3]==0.1.0": nodes[2]
     }
-    graph.exists = mocker.Mock(return_value=False)
 
-    graph._update_from_requirement(
-        requirement, graph.ROOT, mocked_queue, **options
-    )
+    # Check full data.
+    assert graph.data() == {
+        "node_mapping": {
+            "A==0.1.0": wiz.graph.Node(
+                packages["A==0.1.0"], parent_identifiers={"root"}
+            ),
+            "B==1.2.3": wiz.graph.Node(
+                packages["B==1.2.3"], parent_identifiers={"A==0.1.0"}
+            ),
+            "C": wiz.graph.Node(
+                packages["C"], parent_identifiers={"B==1.2.3"}
+            ),
+            "D==3.2.0": wiz.graph.Node(
+                packages["D==3.2.0"], parent_identifiers={"B==1.2.3"}
+            ),
+        },
+        "link_mapping": {
+            "root": {
+                "A==0.1.0": {"requirement": Requirement("::A"), "weight": 1},
+                "D==3.1.0": {
+                    "requirement": Requirement("::D ==3.1.0"), "weight": 2
+                }
+            },
+            "A==0.1.0": {
+                "B==1.2.3": {"requirement": Requirement("::B"), "weight": 1}
+            },
+            "B==1.2.3": {
+                "C": {"requirement": Requirement("::C"), "weight": 1},
+                "D==3.2.0": {
+                    "requirement": Requirement("::D >=3, <4"), "weight": 2
+                },
+            },
+        },
+        "error_mapping": {
+            "root": [
+                "Requirement '::D ==3.1.0' can not be satisfied once 'D==3.1.0'"
+                " is removed from the graph."
+            ]
+        },
+        "conditioned_nodes": [],
+    }
 
-    assert graph._create_node_from_package.call_count == 3
-    for package in packages:
-        graph._create_node_from_package.assert_any_call(package)
 
-    assert graph.create_link.call_count == 3
-    for node in nodes:
-        graph.create_link.assert_any_call(
-            node.identifier,
-            graph.ROOT,
-            requirement,
-            weight=options.get("weight", 1)
-        )
-
-    for node in nodes:
-        node.add_parent.assert_called_once_with(graph.ROOT)
-
-    mocked_queue.put.assert_not_called()
-
-
-def test_graph_update_from_requirements_with_invalid_requirements(
-    mocked_resolver, mocked_package_extract
+@pytest.mark.parametrize("packages", ["conflicting-versions"], indirect=True)
+def test_graph_relink_parents_with_requirement(
+    mocked_resolver, mocked_package_extract, packages
 ):
-    """Fail to update graph with invalid package requirements."""
-    graph = wiz.graph.Graph(mocked_resolver)
-
-    _mapping = {
-        "A==0.1.0": wiz.package.Package(
-            wiz.definition.Definition({
-                "identifier": "A",
-                "version": "0.1.0",
-                "requirements": ["!!!"],
-            })
-        ),
-    }
-
+    """Relink parents after removing a node with new requirement."""
+    requirements = [Requirement("A"), Requirement("D==3.1.0")]
     mocked_package_extract.side_effect = [
-        [_mapping["A==0.1.0"]],
+        [packages["A==0.1.0"]],  [packages["D==3.1.0"]], [packages["B==1.2.3"]],
+        [packages["C"]], [packages["D==3.2.0"]],
     ]
 
-    with pytest.raises(wiz.exception.IncorrectDefinition) as error:
-        graph.update_from_requirements([Requirement("A")], graph.ROOT)
+    # Create graph.
+    graph = wiz.graph.Graph(mocked_resolver)
+    graph.update_from_requirements(requirements)
 
-    assert (
-        "IncorrectDefinition: Package 'A==0.1.0' is incorrect "
-        "[The requirement '!!!' is incorrect]"
-    ) in str(error)
+    # Remove a node.
+    node = graph.node("D==3.2.0")
+    graph.remove_node("D==3.2.0")
+
+    # Relink parent from removed node.
+    graph.relink_parents(node, requirement=Requirement("::D >3"))
+
+    # Check whether the graph has conflicts, conditions or/and errors.
+    assert graph.conflicting() == set()
+    assert graph.conflicting_variant_groups() == []
+    assert graph.conditioned_nodes() == []
+    assert graph.errors() == {}
+
+    # Check full data.
+    assert graph.data() == {
+        "node_mapping": {
+            "A==0.1.0": wiz.graph.Node(
+                packages["A==0.1.0"], parent_identifiers={"root"}
+            ),
+            "B==1.2.3": wiz.graph.Node(
+                packages["B==1.2.3"], parent_identifiers={"A==0.1.0"}
+            ),
+            "C": wiz.graph.Node(
+                packages["C"], parent_identifiers={"B==1.2.3"}
+            ),
+            "D==3.1.0": wiz.graph.Node(
+                packages["D==3.1.0"], parent_identifiers={"B==1.2.3", "root"}
+            ),
+        },
+        "link_mapping": {
+            "root": {
+                "A==0.1.0": {"requirement": Requirement("::A"), "weight": 1},
+                "D==3.1.0": {
+                    "requirement": Requirement("::D ==3.1.0"), "weight": 2
+                }
+            },
+            "A==0.1.0": {
+                "B==1.2.3": {"requirement": Requirement("::B"), "weight": 1}
+            },
+            "B==1.2.3": {
+                "C": {"requirement": Requirement("::C"), "weight": 1},
+                "D==3.1.0": {
+                    "requirement": Requirement("::D >3"), "weight": 2
+                },
+                "D==3.2.0": {
+                    "requirement": Requirement("::D >=3, <4"), "weight": 2
+                },
+            },
+        },
+        "error_mapping": {},
+        "conditioned_nodes": [],
+    }
 
 
-def test_graph_update_from_requirements_with_invalid_conditions(
-    mocked_resolver, mocked_package_extract
+@pytest.mark.parametrize("packages", ["conflicting-versions"], indirect=True)
+def test_graph_relink_parents_unnecessary(
+    mocked_resolver, mocked_package_extract, packages
 ):
-    """Fail to update graph with invalid package conditions."""
-    graph = wiz.graph.Graph(mocked_resolver)
-
-    _mapping = {
-        "A==0.1.0": wiz.package.Package(
-            wiz.definition.Definition({
-                "identifier": "A",
-                "version": "0.1.0",
-                "conditions": ["!!!"],
-            })
-        ),
-    }
-
+    """No need to relink parent when parent does not exist in graph anymore."""
+    requirements = [Requirement("A"), Requirement("D==3.1.0")]
     mocked_package_extract.side_effect = [
-        [_mapping["A==0.1.0"]],
+        [packages["A==0.1.0"]],  [packages["D==3.1.0"]], [packages["B==1.2.3"]],
+        [packages["C"]], [packages["D==3.2.0"]],
     ]
 
-    with pytest.raises(wiz.exception.IncorrectDefinition) as error:
-        graph.update_from_requirements([Requirement("A")], graph.ROOT)
+    # Create graph.
+    graph = wiz.graph.Graph(mocked_resolver)
+    graph.update_from_requirements(requirements)
 
-    assert (
-        "IncorrectDefinition: Package 'A==0.1.0' is incorrect "
-        "[The requirement '!!!' is incorrect]"
-    ) in str(error)
+    # Remove a node.
+    node = graph.node("D==3.2.0")
+    graph.remove_node("D==3.2.0")
+    graph.remove_node("B==1.2.3")
+
+    # Relink parent from removed node.
+    graph.relink_parents(node)
+
+    # Check whether the graph has conflicts, conditions or/and errors.
+    assert graph.conflicting() == set()
+    assert graph.conflicting_variant_groups() == []
+    assert graph.conditioned_nodes() == []
+    assert graph.errors() == {}
+
+    # Check full data.
+    assert graph.data() == {
+        "node_mapping": {
+            "A==0.1.0": wiz.graph.Node(
+                packages["A==0.1.0"], parent_identifiers={"root"}
+            ),
+            "C": wiz.graph.Node(
+                packages["C"], parent_identifiers={"B==1.2.3"}
+            ),
+            "D==3.1.0": wiz.graph.Node(
+                packages["D==3.1.0"], parent_identifiers={"root"}
+            ),
+        },
+        "link_mapping": {
+            "root": {
+                "A==0.1.0": {"requirement": Requirement("::A"), "weight": 1},
+                "D==3.1.0": {
+                    "requirement": Requirement("::D ==3.1.0"), "weight": 2
+                }
+            },
+            "A==0.1.0": {
+                "B==1.2.3": {"requirement": Requirement("::B"), "weight": 1}
+            },
+            "B==1.2.3": {
+                "C": {"requirement": Requirement("::C"), "weight": 1},
+                "D==3.2.0": {
+                    "requirement": Requirement("::D >=3, <4"), "weight": 2
+                },
+            },
+        },
+        "error_mapping": {},
+        "conditioned_nodes": [],
+    }
 
 
-def test_graph_create_node_from_package():
-    """Create node in graph from package."""
-    package = wiz.package.Package(
-        wiz.definition.Definition({
-            "identifier": "A",
-            "version": "0.1.0"
-        })
-    )
-
-    graph = wiz.graph.Graph(None)
-    graph._create_node_from_package(package)
-
-    assert graph._identifiers_per_definition == {"A": {"A==0.1.0"}}
-    assert list(graph._node_mapping.keys()) == ["A==0.1.0"]
-    assert isinstance(graph._node_mapping["A==0.1.0"], wiz.graph.Node)
-
-
-@pytest.mark.parametrize("options", [
-    {},
-    {"weight": 5},
+@pytest.mark.parametrize("options, parent_identifiers", [
+    ({}, set()),
+    ({"parent_identifiers": {"foo"}}, {"foo"}),
 ], ids=[
     "simple",
-    "with-weight",
+    "with-parents"
 ])
-def test_graph_create_link(options):
-    """Create link between two nodes."""
-    requirement = Requirement("A")
+def test_node(mocker, options, parent_identifiers):
+    """Create and use Node instance."""
+    package = mocker.Mock()
 
-    graph = wiz.graph.Graph(None)
-    graph.create_link("child", "parent", requirement, **options)
-
-    assert graph._link_mapping == {
-        "parent": {
-            "child": {
-                "requirement": requirement,
-                "weight": options.get("weight", 1)
-            }
-        }
-    }
-
-
-def test_graph_create_link_overwrite():
-    """Overwrite existing link between two nodes."""
-    graph = wiz.graph.Graph(None)
-    graph._link_mapping = {
-        "parent": {"child": {"requirement": Requirement("A"), "weight": 3}}
-    }
-
-    # Ignore when weight is higher
-    graph.create_link("child", "parent", Requirement("A>2"), weight=4)
-
-    assert graph.link_requirement("child", "parent") == Requirement("A")
-    assert graph.link_weight("child", "parent") == 3
-
-    # Don't ignore when weight is lower
-    graph.create_link("child", "parent", Requirement("A>2"), weight=1)
-
-    assert graph.link_requirement("child", "parent") == Requirement("A>2")
-    assert graph.link_weight("child", "parent") == 1
-
-
-def test_graph_remove_node():
-    """Remove nodes from graph."""
-    graph = wiz.graph.Graph(None)
-    graph._node_mapping = {"A1": "_A1", "A2": "_A2", "B": "B"}
-    graph._identifiers_per_definition = {"defA": ["A1", "A2"], "defB": ["B"]}
-    graph._variants_per_definition = {"_id": ["A1", "A2"]}
-    graph._link_mapping = {"A1": {"B": "LINK"}}
-
-    graph.remove_node("A1")
-
-    assert graph._node_mapping == {"A2": "_A2", "B": "B"}
-    assert graph._identifiers_per_definition == {
-        "defA": ["A1", "A2"], "defB": ["B"]
-    }
-    assert graph._variants_per_definition == {"_id": ["A1", "A2"]}
-    assert graph._link_mapping == {"A1": {"B": "LINK"}}
-
-
-def test_node():
-    """Create and use node."""
-    definition = wiz.definition.Definition({
-        "identifier": "A",
-        "version": "0.1.0",
-        "variants": [{"identifier": "V1"}]
-    })
-
-    package = wiz.package.Package(definition, variant_index=0)
-
-    node = wiz.graph.Node(package)
-    assert node.identifier == "A[V1]==0.1.0"
-    assert node.definition == definition
+    node = wiz.graph.Node(package, **options)
+    assert node.identifier == package.identifier
+    assert node.definition == package.definition
     assert node.package == package
-    assert node.parent_identifiers == set()
+    assert node.parent_identifiers == parent_identifiers
+    assert node.data() == {
+        "package": package,
+        "parents": sorted(parent_identifiers)
+    }
 
     node.add_parent("parent1")
     node.add_parent("parent1")
     node.add_parent("parent2")
 
-    assert node.parent_identifiers == {"parent1", "parent2"}
+    assert node.parent_identifiers == set(
+        itertools.chain(parent_identifiers, {"parent1", "parent2"})
+    )
+    assert node.data() == {
+        "package": package,
+        "parents": sorted(
+            itertools.chain(parent_identifiers, ["parent1", "parent2"])
+        )
+    }
+
+    assert node != 42
+    assert node != wiz.graph.Node(package, **options)
+    assert node == wiz.graph.Node(
+        package, parent_identifiers=set(
+            itertools.chain(parent_identifiers, {"parent1", "parent2"})
+        )
+    )
+
+
+@pytest.mark.parametrize("options, weight", [
+    ({}, 1),
+    ({"weight": 10}, 10),
+], ids=[
+    "simple",
+    "with-weight"
+])
+def test_stored_node(mocker, options, weight):
+    """Create and use StoredNode instance."""
+    package = mocker.Mock()
+
+    stored_node = wiz.graph.StoredNode(
+        "__REQUIREMENT__", package, "__PARENT_ID__", **options
+    )
+    assert stored_node.identifier == package.identifier
+    assert stored_node.requirement == "__REQUIREMENT__"
+    assert stored_node.package == package
+    assert stored_node.parent_identifier == "__PARENT_ID__"
+    assert stored_node.weight == weight
+
+    assert stored_node.data() == {
+        "requirement": "__REQUIREMENT__",
+        "package": package,
+        "parent_identifier": "__PARENT_ID__",
+        "weight": weight
+    }
+
+    assert stored_node != 42
+    assert stored_node != wiz.graph.StoredNode(
+        "__OTHER_REQUIREMENT__", package, "__PARENT_ID__", **options
+    )
+    assert stored_node == wiz.graph.StoredNode(
+        "__REQUIREMENT__", package, "__PARENT_ID__", **options
+    )
 
 
 def test_distance_queue():
-    """Create and use distance queue."""
+    """Create and use _DistanceQueue instance."""
     queue = wiz.graph._DistanceQueue()
     assert queue.empty() is True
 

--- a/test/unit/test_graph.py
+++ b/test/unit/test_graph.py
@@ -748,25 +748,25 @@ def test_resolver_compute_packages_reach_maximum(
         resolver.compute_packages("__REQS__")
 
     assert (
-        "Failed to resolve graph at combination #6:\n\n"
+        "Failed to resolve graph at combination #5:\n\n"
         "Error!"
     ) in str(error.value)
 
     assert resolver._conflicting_combinations == collections.deque()
 
-    for combination in combinations[:6]:
+    for combination in combinations[:5]:
         combination.resolve_conflicts.assert_called_once_with()
         combination.validate.assert_called_once_with()
         combination.extract_packages.assert_called_once_with()
 
-    for combination in combinations[6:]:
+    for combination in combinations[5:]:
         combination.resolve_conflicts.assert_not_called()
         combination.validate.assert_not_called()
         combination.extract_packages.assert_not_called()
 
     mocked_graph.update_from_requirements.assert_called_once_with("__REQS__")
 
-    assert mocked_fetch_next_combination.call_count == 7
+    assert mocked_fetch_next_combination.call_count == 6
     mocked_extract_combinations.assert_called_once_with(mocked_graph)
 
 

--- a/test/unit/test_graph.py
+++ b/test/unit/test_graph.py
@@ -305,6 +305,226 @@ def _packages_with_conflicting_variants():
     }
 
 
+def test_compute_distance_mapping_empty(mocked_graph):
+    """Compute distance mapping from empty graph."""
+    mocked_graph.outcoming.return_value = []
+    assert wiz.graph.compute_distance_mapping(mocked_graph) == {
+        "root": {"distance": 0, "parent": "root"}
+    }
+
+
+def test_compute_distance_mapping_one_node(mocker, mocked_graph):
+    """Compute distance mapping from graph with one node."""
+    identifiers = ["root", "A"]
+    weights = {"root": {"A": 1}}
+
+    # mock nodes in the graph.
+    nodes = [mocker.Mock(identifier=_id) for _id in identifiers]
+    mocked_graph.nodes.return_value = nodes
+
+    # mock graph traversal.
+    mocked_graph.outcoming = lambda _id: weights.get(_id, {}).keys()
+    mocked_graph.link_weight = lambda _id1, _id2: weights[_id2][_id1]
+
+    assert wiz.graph.compute_distance_mapping(mocked_graph) == {
+        "root": {"distance": 0, "parent": "root"},
+        "A": {"distance": 1, "parent": "root"}
+    }
+
+
+def test_compute_distance_mapping_two_nodes(mocker, mocked_graph):
+    """Compute distance mapping from graph with two nodes."""
+    identifiers = ["root", "A", "B"]
+    weights = {"root": {"A": 1, "B": 2}}
+
+    # mock nodes in the graph.
+    nodes = [mocker.Mock(identifier=_id) for _id in identifiers]
+    mocked_graph.nodes.return_value = nodes
+
+    # mock graph traversal.
+    mocked_graph.outcoming = lambda _id: weights.get(_id, {}).keys()
+    mocked_graph.link_weight = lambda _id1, _id2: weights[_id2][_id1]
+
+    assert wiz.graph.compute_distance_mapping(mocked_graph) == {
+        "root": {"distance": 0, "parent": "root"},
+        "A": {"distance": 1, "parent": "root"},
+        "B": {"distance": 2, "parent": "root"}
+    }
+
+
+def test_compute_distance_mapping_three_nodes(mocker, mocked_graph):
+    """Compute distance mapping from graph with three nodes."""
+    identifiers = ["root", "A", "B", "C"]
+    weights = {"root": {"A": 1, "B": 2, "C": 3}}
+
+    # mock nodes in the graph.
+    nodes = [mocker.Mock(identifier=_id) for _id in identifiers]
+    mocked_graph.nodes.return_value = nodes
+
+    # mock graph traversal.
+    mocked_graph.outcoming = lambda _id: weights.get(_id, {}).keys()
+    mocked_graph.link_weight = lambda _id1, _id2: weights[_id2][_id1]
+
+    assert wiz.graph.compute_distance_mapping(mocked_graph) == {
+        "root": {"distance": 0, "parent": "root"},
+        "A": {"distance": 1, "parent": "root"},
+        "B": {"distance": 2, "parent": "root"},
+        "C": {"distance": 3, "parent": "root"}
+    }
+
+
+def test_compute_distance_mapping_two_levels(mocker, mocked_graph):
+    """Compute distance mapping from graph with two levels of dependency."""
+    identifiers = ["root", "A", "B"]
+    weights = {"root": {"A": 1}, "A": {"B": 1}}
+
+    # mock nodes in the graph.
+    nodes = [mocker.Mock(identifier=_id) for _id in identifiers]
+    mocked_graph.nodes.return_value = nodes
+
+    # mock graph traversal.
+    mocked_graph.outcoming = lambda _id: weights.get(_id, {}).keys()
+    mocked_graph.link_weight = lambda _id1, _id2: weights[_id2][_id1]
+
+    assert wiz.graph.compute_distance_mapping(mocked_graph) == {
+        "root": {"distance": 0, "parent": "root"},
+        "A": {"distance": 1, "parent": "root"},
+        "B": {"distance": 2, "parent": "A"}
+    }
+
+
+def test_compute_distance_mapping_three_levels(mocker, mocked_graph):
+    """Compute distance mapping from graph with three levels of dependency."""
+    identifiers = ["root", "A", "B", "C"]
+    weights = {"root": {"A": 1}, "A": {"B": 1}, "B": {"C": 1}}
+
+    # mock nodes in the graph.
+    nodes = [mocker.Mock(identifier=_id) for _id in identifiers]
+    mocked_graph.nodes.return_value = nodes
+
+    # mock graph traversal.
+    mocked_graph.outcoming = lambda _id: weights.get(_id, {}).keys()
+    mocked_graph.link_weight = lambda _id1, _id2: weights[_id2][_id1]
+
+    assert wiz.graph.compute_distance_mapping(mocked_graph) == {
+        "root": {"distance": 0, "parent": "root"},
+        "A": {"distance": 1, "parent": "root"},
+        "B": {"distance": 2, "parent": "A"},
+        "C": {"distance": 3, "parent": "B"}
+    }
+
+
+def test_compute_distance_mapping_circular_dependency(mocker, mocked_graph):
+    """Compute distance mapping from graph with circular dependency."""
+    identifiers = ["root", "A", "B"]
+    weights = {"root": {"A": 1, "B": 2}, "A": {"B": 1}, "B": {"A": 1}}
+
+    # mock nodes in the graph.
+    nodes = [mocker.Mock(identifier=_id) for _id in identifiers]
+    mocked_graph.nodes.return_value = nodes
+
+    # mock graph traversal.
+    mocked_graph.outcoming = lambda _id: weights.get(_id, {}).keys()
+    mocked_graph.link_weight = lambda _id1, _id2: weights[_id2][_id1]
+
+    assert wiz.graph.compute_distance_mapping(mocked_graph) == {
+        "root": {"distance": 0, "parent": "root"},
+        "A": {"distance": 1, "parent": "root"},
+        "B": {"distance": 2, "parent": "root"}
+    }
+
+
+def test_compute_distance_mapping_multi_levels(mocker, mocked_graph):
+    """Compute distance mapping from graph with multi levels of dependency."""
+    identifiers = ["root", "A", "B", "C", "D", "E", "F", "G"]
+    weights = {
+        "root": {"A": 1, "B": 2},
+        "A": {"C": 1, "D": 2},
+        "B": {"D": 1, "F": 2, "G": 3},
+        "D": {"E": 1}
+    }
+
+    # mock nodes in the graph.
+    nodes = [mocker.Mock(identifier=_id) for _id in identifiers]
+    mocked_graph.nodes.return_value = nodes
+
+    # mock graph traversal.
+    mocked_graph.outcoming = lambda _id: weights.get(_id, {}).keys()
+    mocked_graph.link_weight = lambda _id1, _id2: weights[_id2][_id1]
+
+    assert wiz.graph.compute_distance_mapping(mocked_graph) == {
+        "root": {"distance": 0, "parent": "root"},
+        "A": {"distance": 1, "parent": "root"},
+        "B": {"distance": 2, "parent": "root"},
+        "C": {"distance": 2, "parent": "A"},
+        "D": {"distance": 3, "parent": "A"},
+        "E": {"distance": 4, "parent": "D"},
+        "F": {"distance": 4, "parent": "B"},
+        "G": {"distance": 5, "parent": "B"},
+    }
+
+
+def test_compute_distance_mapping_unreachable_nodes(mocker, mocked_graph):
+    """Compute distance mapping from graph with unreachable nodes."""
+    identifiers = ["root", "A", "B", "C", "D", "E", "F"]
+    weights = {
+        "root": {"A": 1},
+        "A": {"C": 1, "E": 2, "F": 3},
+        "B": {"F": 1, "D": 2},
+    }
+
+    # mock nodes in the graph.
+    nodes = [mocker.Mock(identifier=_id) for _id in identifiers]
+    mocked_graph.nodes.return_value = nodes
+
+    # mock graph traversal.
+    mocked_graph.outcoming = lambda _id: weights.get(_id, {}).keys()
+    mocked_graph.link_weight = lambda _id1, _id2: weights[_id2][_id1]
+
+    assert wiz.graph.compute_distance_mapping(mocked_graph) == {
+        "root": {"distance": 0, "parent": "root"},
+        "A": {"distance": 1, "parent": "root"},
+        "B": {"distance": None, "parent": None},
+        "C": {"distance": 2, "parent": "A"},
+        "D": {"distance": None, "parent": None},
+        "E": {"distance": 3, "parent": "A"},
+        "F": {"distance": 4, "parent": "A"},
+    }
+
+
+def test_compute_distance_mapping_complex(mocker, mocked_graph):
+    """Compute distance mapping from graph with complex graph."""
+    identifiers = ["root", "A", "B", "C", "D", "E", "F", "G"]
+    weights = {
+        "root": {"A": 1, "B": 2, "F": 3},
+        "A": {"C": 1, "D": 2},
+        "B": {"D": 1, "F": 2, "G": 3},
+        "C": {"G": 1},
+        "D": {"E": 1},
+        "E": {"A": 1},
+        "G": {"B": 1}
+    }
+
+    # mock nodes in the graph.
+    nodes = [mocker.Mock(identifier=_id) for _id in identifiers]
+    mocked_graph.nodes.return_value = nodes
+
+    # mock graph traversal.
+    mocked_graph.outcoming = lambda _id: weights.get(_id, {}).keys()
+    mocked_graph.link_weight = lambda _id1, _id2: weights[_id2][_id1]
+
+    assert wiz.graph.compute_distance_mapping(mocked_graph) == {
+        "root": {"distance": 0, "parent": "root"},
+        "A": {"distance": 1, "parent": "root"},
+        "B": {"distance": 2, "parent": "root"},
+        "C": {"distance": 2, "parent": "A"},
+        "D": {"distance": 3, "parent": "A"},
+        "E": {"distance": 4, "parent": "D"},
+        "F": {"distance": 3, "parent": "root"},
+        "G": {"distance": 3, "parent": "C"},
+    }
+
+
 def test_combined_requirements(mocked_graph):
     """Combine nodes requirements."""
     versions = ["1.2.3", "1.9.2", "3.0.0"]

--- a/test/unit/test_graph.py
+++ b/test/unit/test_graph.py
@@ -598,8 +598,9 @@ def test_resolver_compute_packages_fail(
         resolver.compute_packages("__REQS__")
 
     assert (
-        "Failed to resolve graph at combination #{}".format(combination_number)
-    ) in str(error)
+        "Failed to resolve graph at combination #{}:\n\n"
+        "Error!".format(combination_number)
+    ) in str(error.value)
 
     assert resolver._conflicting_combinations == collections.deque()
 
@@ -654,8 +655,14 @@ def test_resolver_compute_packages_fail_from_conflicts(
         resolver.compute_packages("__REQS__")
 
     assert (
-        "Failed to resolve graph at combination #{}".format(combination_number)
-    ) in str(error)
+        "Failed to resolve graph at combination #{0}:\n\n"
+        "The dependency graph could not be resolved due to the following "
+        "requirement conflicts:\n"
+        "  * bar >1 \t[foo{1}]\n"
+        "  * bar <1 \t[bim{1}]\n".format(
+            combination_number, combination_number-1
+        )
+    ) in str(error.value)
 
     assert resolver.conflicting_variants == set()
 
@@ -1148,7 +1155,7 @@ def test_combined_requirements_error(mocked_graph):
     assert (
         "Impossible to combine requirements with different names "
         "[foo, incorrect]."
-    ) in str(error)
+    ) in str(error.value)
 
 
 def test_extract_conflicting_requirements(mocked_graph):
@@ -1429,11 +1436,11 @@ def test_graph_link_requirement(
 
     with pytest.raises(ValueError) as error:
         graph.link_requirement(identifier, "whatever")
-    assert "No link recorded for node: 'whatever'" in str(error)
+    assert "No link recorded for node: 'whatever'" in str(error.value)
 
     with pytest.raises(ValueError) as error:
         graph.link_requirement("whatever", "root")
-    assert "No link recorded for node: 'whatever'" in str(error)
+    assert "No link recorded for node: 'whatever'" in str(error.value)
 
 
 @pytest.mark.parametrize(
@@ -1460,11 +1467,11 @@ def test_graph_link_weight(
 
     with pytest.raises(ValueError) as error:
         graph.link_weight(identifier, "whatever")
-    assert "No link recorded for node: 'whatever'" in str(error)
+    assert "No link recorded for node: 'whatever'" in str(error.value)
 
     with pytest.raises(ValueError) as error:
         graph.link_weight("whatever", "root")
-    assert "No link recorded for node: 'whatever'" in str(error)
+    assert "No link recorded for node: 'whatever'" in str(error.value)
 
 
 @pytest.mark.parametrize("packages", ["many"], indirect=True)
@@ -3149,7 +3156,7 @@ def test_graph_remove_error(mocked_resolver):
     with pytest.raises(ValueError) as error:
         graph.remove_node("A==0.1.0")
 
-    assert "Node can not be removed: A==0.1.0" in str(error)
+    assert "Node can not be removed: A==0.1.0" in str(error.value)
 
 
 @pytest.mark.parametrize("packages", ["conflicting-versions"], indirect=True)

--- a/test/unit/test_package.py
+++ b/test/unit/test_package.py
@@ -467,6 +467,34 @@ def test_create_package_with_variant_error():
     ) in str(error)
 
 
+def test_incorrect_package():
+    """Fail to create a package."""
+    # Requesting non exiting variant
+    definition = wiz.definition.Definition({"identifier": "test"})
+
+    with pytest.raises(wiz.exception.PackageError) as error:
+        wiz.package.Package(definition, variant_index=3)
+
+    assert (
+        "Package cannot be created from definition 'test' with variant "
+        "index #3."
+    ) in str(error)
+
+    # Failing to request variant
+    definition = wiz.definition.Definition({
+        "identifier": "test",
+        "variants": [{"identifier": "V1"}]
+    })
+
+    with pytest.raises(wiz.exception.PackageError) as error:
+        wiz.package.Package(definition)
+
+    assert (
+        "Package cannot be created from definition 'test' as no variant "
+        "index is defined."
+    ) in str(error)
+
+
 def test_minimal_package():
     """Create a minimal package."""
     definition = wiz.definition.Definition({"identifier": "test"})

--- a/test/unit/test_registry.py
+++ b/test/unit/test_registry.py
@@ -284,7 +284,7 @@ def test_install_to_path(
 ):
     """Install definitions to path."""
     mocked_fetch_definition_mapping.return_value = "__MAPPING__"
-    mocked_fetch_definition.side_effect = wiz.exception.RequestNotFound()
+    mocked_fetch_definition.side_effect = wiz.exception.RequestNotFound("Error")
 
     wiz.registry.install_to_path(
         mocked_definitions, temporary_directory
@@ -327,7 +327,7 @@ def test_install_to_path_with_relative_path(
     os.makedirs(path)
 
     mocked_fetch_definition_mapping.return_value = "__MAPPING__"
-    mocked_fetch_definition.side_effect = wiz.exception.RequestNotFound()
+    mocked_fetch_definition.side_effect = wiz.exception.RequestNotFound("Error")
 
     wiz.registry.install_to_path(
         mocked_definitions, path
@@ -390,7 +390,7 @@ def test_install_to_path_error_definition_exists(
     """Fail to install definitions when definition exists."""
     mocked_fetch_definition_mapping.return_value = "__MAPPING__"
     mocked_fetch_definition.side_effect = [
-        wiz.exception.RequestNotFound(),
+        wiz.exception.RequestNotFound("Error"),
         wiz.definition.Definition({
             "identifier": "bar",
         }),
@@ -429,7 +429,7 @@ def test_install_to_path_overwrite(
     """Install definitions while overwriting existing definitions."""
     mocked_fetch_definition_mapping.return_value = "__MAPPING__"
     mocked_fetch_definition.side_effect = [
-        wiz.exception.RequestNotFound(),
+        wiz.exception.RequestNotFound("Error"),
         wiz.definition.Definition(
             {"identifier": "bar"},
             path="/path/to/registry/bar/bar.json"

--- a/test/unit/test_system.py
+++ b/test/unit/test_system.py
@@ -94,9 +94,9 @@ def test_query_platform_error(mocked_platform_system):
 def test_query_version_error(mocked_platform_system, mocked_platform_linux):
     """Fails to query system mapping from incorrect os version."""
     mocked_platform_system.return_value = "linux"
-    mocked_platform_linux.side_effect = wiz.exception.InvalidVersion
+    mocked_platform_linux.side_effect = wiz.exception.VersionError("Error")
 
-    with pytest.raises(wiz.exception.IncorrectDefinition):
+    with pytest.raises(wiz.exception.CurrentSystemError):
         wiz.system.query()
 
 
@@ -323,5 +323,5 @@ def test_validate_requirement_error():
         "system": {"os": "!!!"}
     })
 
-    with pytest.raises(wiz.exception.IncorrectDefinition):
-        print(wiz.system.validate(definition, {}))
+    with pytest.raises(wiz.exception.DefinitionError):
+        wiz.system.validate(definition, {})

--- a/test/unit/test_utility.py
+++ b/test/unit/test_utility.py
@@ -5,6 +5,7 @@ import base64
 import hashlib
 
 import pytest
+import six
 
 import wiz.definition
 import wiz.package
@@ -44,7 +45,7 @@ def mocked_match(mocker):
 def test_encode_and_decode(element):
     """Encode *element* and immediately decode it."""
     encoded = wiz.utility.encode(element)
-    assert isinstance(encoded, bytes)
+    assert isinstance(encoded, six.string_types)
     assert element == wiz.utility.decode(encoded)
 
 

--- a/test/unit/test_utility.py
+++ b/test/unit/test_utility.py
@@ -239,7 +239,7 @@ def test_extract_version_ranges(requirement, expected):
 ])
 def test_extract_version_ranges_error(requirement, expected):
     """Fail to extract version ranges from requirements."""
-    with pytest.raises(wiz.exception.InvalidRequirement) as error:
+    with pytest.raises(wiz.exception.RequirementError) as error:
         wiz.utility.extract_version_ranges(requirement)
 
     assert expected in str(error)
@@ -292,7 +292,7 @@ def test_update_minimum_version(version, ranges, expected):
 
 def test_update_minimum_version_fail():
     """Fail to update range with minimum value."""
-    with pytest.raises(wiz.exception.InvalidRequirement) as error:
+    with pytest.raises(wiz.exception.RequirementError) as error:
         wiz.utility._update_minimum_version((1, 2, 3), [(None, (1,))])
 
     assert (
@@ -348,7 +348,7 @@ def test_update_maximum_version(version, ranges, expected):
 
 def test_update_maximum_version_fail():
     """Fail to update range with maximum value."""
-    with pytest.raises(wiz.exception.InvalidRequirement) as error:
+    with pytest.raises(wiz.exception.RequirementError) as error:
         wiz.utility._update_maximum_version((1, 2, 3), [((2,), None)])
 
     assert (
@@ -410,7 +410,7 @@ def test_update_version_ranges(excluded, ranges, expected):
 
 def test_update_version_ranges_fail():
     """Fail to update version ranges from excluded version range."""
-    with pytest.raises(wiz.exception.InvalidRequirement) as error:
+    with pytest.raises(wiz.exception.RequirementError) as error:
         wiz.utility._update_version_ranges(((0,), (3,)), [((1,), (2,))])
 
     assert (

--- a/test/unit/test_utility.py
+++ b/test/unit/test_utility.py
@@ -680,3 +680,31 @@ def test_match(package_data, variant_index, requirement, expected):
 def test_extract_namespace(requirement, namespace, identifier):
     """Extract namespace and identifier from requirement."""
     assert wiz.utility.extract_namespace(requirement) == (namespace, identifier)
+
+
+@pytest.mark.parametrize("requirements1, requirements2, expected", [
+    ([], [], False),
+    (["bim > 3", "bah"], ["zim"], False),
+    (["bim > 3", "bah"], ["bim"], False),
+    (["bim > 3", "bah"], ["bim < 3"], True),
+], ids=[
+    "without-requirements",
+    "different-requirements",
+    "compatible-requirements",
+    "incompatible-requirements",
+])
+def test_check_conflicting_requirements(requirements1, requirements2, expected):
+    """Check whether some requirements are conflicting between packages."""
+    data1 = {"identifier": "foo"}
+    if len(requirements1):
+        data1["requirements"] = requirements1
+
+    data2 = {"identifier": "bar"}
+    if len(requirements2):
+        data2["requirements"] = requirements2
+
+    package1 = wiz.package.Package(wiz.definition.Definition(data1))
+    package2 = wiz.package.Package(wiz.definition.Definition(data2))
+
+    result = wiz.utility.check_conflicting_requirements(package1, package2)
+    assert result == expected

--- a/test/unit/test_utility.py
+++ b/test/unit/test_utility.py
@@ -7,6 +7,7 @@ import hashlib
 import pytest
 
 import wiz.definition
+import wiz.package
 import wiz.utility
 from wiz.utility import Requirement
 
@@ -15,6 +16,12 @@ from wiz.utility import Requirement
 def mocked_extract_version_ranges(mocker):
     """Return mocked wiz.utility.extract_version_ranges function."""
     return mocker.patch.object(wiz.utility, "extract_version_ranges")
+
+
+@pytest.fixture()
+def mocked_match(mocker):
+    """Return mocked wiz.utility.match function."""
+    return mocker.patch.object(wiz.utility, "match")
 
 
 @pytest.mark.parametrize("element", [
@@ -568,3 +575,108 @@ def test_deep_update(mapping1, mapping2, expected):
     assert wiz.utility.deep_update(mapping1, mapping2) == expected
     assert mapping1 == expected
     assert mapping2 == _mapping2
+
+
+@pytest.mark.parametrize("package_data, variant_index, requirement, expected", [
+    ({"identifier": "A"}, None, Requirement("A"), Requirement("::A")),
+    (
+        {"identifier": "A", "version": "2"}, None,
+        Requirement("A > 1"), Requirement("::A > 1")
+    ),
+    (
+        {"identifier": "A", "namespace": "foo"}, None,
+        Requirement("A"), Requirement("foo::A")
+    ),
+    (
+        {"identifier": "A", "namespace": "foo::bar"}, None,
+        Requirement("A"), Requirement("foo::bar::A")
+    ),
+    (
+        {"identifier": "A", "variants": [{"identifier": "V1"}]}, 0,
+        Requirement("A[V1]"), Requirement("::A[V1]")
+    )
+], ids=[
+    "simple",
+    "with-version",
+    "with-namespace",
+    "with-long-namespace",
+    "with-variant",
+])
+def test_sanitize_requirement(
+    mocked_match, package_data, variant_index, requirement, expected
+):
+    """Return qualified requirement depending on package's namespace."""
+    mocked_match.return_value = True
+    package = wiz.package.Package(
+        wiz.definition.Definition(package_data), variant_index=variant_index
+    )
+    assert wiz.utility.sanitize_requirement(requirement, package) == expected
+
+
+def test_sanitize_requirement_error(mocked_match):
+    """Fail to return qualified requirement."""
+    mocked_match.return_value = False
+    package = wiz.package.Package(
+        wiz.definition.Definition({"identifier": "B"})
+    )
+
+    with pytest.raises(ValueError) as error:
+        wiz.utility.sanitize_requirement(Requirement("A"), package)
+
+    assert "Requirement 'A' is incompatible with package 'B'" in str(error)
+
+
+@pytest.mark.parametrize("package_data, variant_index, requirement, expected", [
+    ({"identifier": "A"}, None, Requirement("A"), True),
+    ({"identifier": "B"}, None, Requirement("A"), False),
+    ({"identifier": "A", "version": "1"}, None, Requirement("A>=1"), True),
+    ({"identifier": "A", "version": "0.1.0"}, None, Requirement("A>=1"), False),
+    ({"identifier": "A", "namespace": "ba"}, None, Requirement("A"), True),
+    ({"identifier": "A", "namespace": "ba"}, None, Requirement("ba::A"), True),
+    ({"identifier": "A", "namespace": "to"}, None, Requirement("ba::A"), False),
+    (
+        {"identifier": "A", "variants": [{"identifier": "V1"}]}, 0,
+        Requirement("A"), True
+    ),
+    (
+        {"identifier": "A", "variants": [{"identifier": "V1"}]}, 0,
+        Requirement("A[V1]"), True
+    ),
+    (
+        {"identifier": "A", "variants": [{"identifier": "V1"}]}, 0,
+        Requirement("A[V3]"), False
+    ),
+], ids=[
+    "matching-identifier",
+    "non-matching-identifier",
+    "matching-version",
+    "non-matching-version",
+    "matching-namespace1",
+    "matching-namespace1",
+    "non-matching-namespace",
+    "matching-variant1",
+    "matching-variant2",
+    "non-matching-variant",
+])
+def test_match(package_data, variant_index, requirement, expected):
+    """Return whether requirement is compatible with package."""
+    package = wiz.package.Package(
+        wiz.definition.Definition(package_data), variant_index=variant_index
+    )
+    assert wiz.utility.match(requirement, package) == expected
+
+
+@pytest.mark.parametrize("requirement, namespace, identifier", [
+    (Requirement("A"), None, "A"),
+    (Requirement("::A"), None, "A"),
+    (Requirement("foo::A"), "foo", "A"),
+    (Requirement("foo::bar::A"), "foo::bar", "A"),
+], ids=[
+    "without-namespace",
+    "qualified-without-namespace",
+    "with-namespace",
+    "with-long-namespace",
+])
+def test_extract_namespace(requirement, namespace, identifier):
+    """Extract namespace and identifier from requirement."""
+    assert wiz.utility.extract_namespace(requirement) == (namespace, identifier)

--- a/test/unit/test_validator.py
+++ b/test/unit/test_validator.py
@@ -191,7 +191,7 @@ def test_validate_definition_with_variants():
 ])
 def test_validate_definition_failed(value, message):
     """Raise error when data is incorrect."""
-    with pytest.raises(wiz.exception.IncorrectDefinition) as error:
+    with pytest.raises(wiz.exception.DefinitionError) as error:
         wiz.validator.validate_definition(value)
 
     assert message in str(error)

--- a/test/unit/test_wiz.py
+++ b/test/unit/test_wiz.py
@@ -219,17 +219,22 @@ def test_fetch_package_request_from_command_error():
         wiz.fetch_package_request_from_command("app", definition_mapping)
 
 
-@pytest.mark.parametrize("options", [
-    {},
-    {"environ_mapping": "__ENVIRON__"},
+@pytest.mark.parametrize("options, environ, max_combinations, max_attempts", [
+    ({}, None, None, None),
+    ({"environ_mapping": "__ENVIRON__"}, "__ENVIRON__", None, None),
+    ({"maximum_combinations": 1}, None, 1, None),
+    ({"maximum_attempts": 1}, None, None, 1),
 ], ids=[
-    "without-environ",
+    "simple",
     "with-environ",
+    "with-maximum-combinations",
+    "with-maximum-attempts",
 ])
 def test_resolve_context(
     mocked_registry_defaults, mocked_fetch_definition_mapping,
     mocked_graph_resolver, mocked_environ_initiate,
-    mocked_package_extract_context, mocked_utility_encode, mocker, options
+    mocked_package_extract_context, mocked_utility_encode, mocker, options,
+    environ, max_combinations, max_attempts
 ):
     """Get resolved context mapping."""
     requests = ["test1 >=10, < 11", "test2", "test3[variant]"]
@@ -270,32 +275,37 @@ def test_resolve_context(
     mocked_fetch_definition_mapping.assert_not_called()
 
     mocked_graph_resolver.assert_called_once_with(
-        "__PACKAGE_DEFINITIONS__"
+        "__PACKAGE_DEFINITIONS__",
+        maximum_combinations=max_combinations,
+        maximum_attempts=max_attempts
     )
     mocked_resolver.compute_packages.assert_called_once_with([
         Requirement(request) for request in requests
     ])
 
-    mocked_environ_initiate.assert_called_once_with(
-        options.get("environ_mapping")
-    )
+    mocked_environ_initiate.assert_called_once_with(environ)
 
     mocked_package_extract_context.assert_called_once_with(
         packages, environ_mapping="__INITIAL_ENVIRON__"
     )
 
 
-@pytest.mark.parametrize("options", [
-    {},
-    {"environ_mapping": "__ENVIRON__"},
+@pytest.mark.parametrize("options, environ, max_combinations, max_attempts", [
+    ({}, None, None, None),
+    ({"environ_mapping": "__ENVIRON__"}, "__ENVIRON__", None, None),
+    ({"maximum_combinations": 1}, None, 1, None),
+    ({"maximum_attempts": 1}, None, None, 1),
 ], ids=[
-    "without-environ",
+    "simple",
     "with-environ",
+    "with-maximum-combinations",
+    "with-maximum-attempts",
 ])
 def test_resolve_context_with_default_definition_mapping(
     mocked_registry_defaults, mocked_fetch_definition_mapping,
     mocked_graph_resolver, mocked_environ_initiate,
-    mocked_package_extract_context, mocked_utility_encode, mocker, options
+    mocked_package_extract_context, mocked_utility_encode, mocker, options,
+    environ, max_combinations, max_attempts
 ):
     """Get resolved context mapping with default definition mapping."""
     requests = ["test1 >=10, < 11", "test2", "test3[variant]"]
@@ -336,32 +346,37 @@ def test_resolve_context_with_default_definition_mapping(
     mocked_fetch_definition_mapping.asset_called_once_with(paths)
 
     mocked_graph_resolver.assert_called_once_with(
-        "__PACKAGE_DEFINITIONS__"
+        "__PACKAGE_DEFINITIONS__",
+        maximum_combinations=max_combinations,
+        maximum_attempts=max_attempts
     )
     mocked_resolver.compute_packages.assert_called_once_with([
         Requirement(request) for request in requests
     ])
 
-    mocked_environ_initiate.assert_called_once_with(
-        options.get("environ_mapping")
-    )
+    mocked_environ_initiate.assert_called_once_with(environ)
 
     mocked_package_extract_context.assert_called_once_with(
         packages, environ_mapping="__INITIAL_ENVIRON__"
     )
 
 
-@pytest.mark.parametrize("options", [
-    {},
-    {"environ_mapping": "__ENVIRON__"},
+@pytest.mark.parametrize("options, environ, max_combinations, max_attempts", [
+    ({}, None, None, None),
+    ({"environ_mapping": "__ENVIRON__"}, "__ENVIRON__", None, None),
+    ({"maximum_combinations": 1}, None, 1, None),
+    ({"maximum_attempts": 1}, None, None, 1),
 ], ids=[
-    "without-environ",
+    "simple",
     "with-environ",
+    "with-maximum-combinations",
+    "with-maximum-attempts",
 ])
 def test_resolve_context_with_implicit_packages(
     mocked_registry_defaults, mocked_fetch_definition_mapping,
     mocked_graph_resolver, mocked_environ_initiate,
-    mocked_package_extract_context, mocked_utility_encode, mocker, options
+    mocked_package_extract_context, mocked_utility_encode, mocker, options,
+    environ, max_combinations, max_attempts
 ):
     """Get resolved context mapping with implicit packages."""
     requests = ["test1 >=10, < 11", "test2", "test3[variant]"]
@@ -404,32 +419,37 @@ def test_resolve_context_with_implicit_packages(
     mocked_fetch_definition_mapping.asset_called_once_with(paths)
 
     mocked_graph_resolver.assert_called_once_with(
-        "__PACKAGE_DEFINITIONS__"
+        "__PACKAGE_DEFINITIONS__",
+        maximum_combinations=max_combinations,
+        maximum_attempts=max_attempts
     )
     mocked_resolver.compute_packages.assert_called_once_with([
         Requirement(request) for request in implicit + requests
     ])
 
-    mocked_environ_initiate.assert_called_once_with(
-        options.get("environ_mapping")
-    )
+    mocked_environ_initiate.assert_called_once_with(environ)
 
     mocked_package_extract_context.assert_called_once_with(
         packages, environ_mapping="__INITIAL_ENVIRON__"
     )
 
 
-@pytest.mark.parametrize("options", [
-    {},
-    {"environ_mapping": "__ENVIRON__"},
+@pytest.mark.parametrize("options, environ, max_combinations, max_attempts", [
+    ({}, None, None, None),
+    ({"environ_mapping": "__ENVIRON__"}, "__ENVIRON__", None, None),
+    ({"maximum_combinations": 1}, None, 1, None),
+    ({"maximum_attempts": 1}, None, None, 1),
 ], ids=[
-    "without-environ",
+    "simple",
     "with-environ",
+    "with-maximum-combinations",
+    "with-maximum-attempts",
 ])
 def test_resolve_context_with_implicit_packages_ignored(
     mocked_registry_defaults, mocked_fetch_definition_mapping,
     mocked_graph_resolver, mocked_environ_initiate,
-    mocked_package_extract_context, mocked_utility_encode, mocker, options
+    mocked_package_extract_context, mocked_utility_encode, mocker, options,
+    environ, max_combinations, max_attempts
 ):
     """Get resolved context mapping with implicit packages ignored."""
     requests = ["test1 >=10, < 11", "test2", "test3[variant]"]
@@ -473,15 +493,15 @@ def test_resolve_context_with_implicit_packages_ignored(
     mocked_fetch_definition_mapping.asset_called_once_with(paths)
 
     mocked_graph_resolver.assert_called_once_with(
-        "__PACKAGE_DEFINITIONS__"
+        "__PACKAGE_DEFINITIONS__",
+        maximum_combinations=max_combinations,
+        maximum_attempts=max_attempts
     )
     mocked_resolver.compute_packages.assert_called_once_with([
         Requirement(request) for request in requests
     ])
 
-    mocked_environ_initiate.assert_called_once_with(
-        options.get("environ_mapping")
-    )
+    mocked_environ_initiate.assert_called_once_with(environ)
 
     mocked_package_extract_context.assert_called_once_with(
         packages, environ_mapping="__INITIAL_ENVIRON__"


### PR DESCRIPTION
Refactor graph resolver to:
* Improve separation of concern between high level resolution and combination resolution
* Fix handling of circular conflicts (#55)
* Encapsulate relinking errors to prevent raising an error when not necessary (#53)
* Optimize variants permutations to prevent wasting resolution time with incompatible combinations (#52)
* Fix handling of version dropdown (#9, #20)