### PR TITLE
Improve relinking conflicts

### DIFF
--- a/doc/api_reference/graph.rst
+++ b/doc/api_reference/graph.rst
@@ -3,3 +3,4 @@ wiz.graph
 *********
 
 .. automodule:: wiz.graph
+    :private-members:

--- a/doc/release/migration_notes.rst
+++ b/doc/release/migration_notes.rst
@@ -7,6 +7,21 @@ Migration notes
 This section will show more detailed information when relevant for switching to
 a new version, such as when upgrading involves backwards incompatibilities.
 
+.. _release/migration/3.5.0:
+
+Migrate to 3.5.0
+================
+
+.. rubric:: API
+
+The following functions have been made private:
+
+* :func:`wiz.graph._compute_distance_mapping`
+* :func:`wiz.graph._generate_variant_permutations`
+* :func:`wiz.graph._compute_conflicting_matrix`
+* :func:`wiz.graph._combined_requirements`
+* :func:`wiz.graph._extract_conflicting_requirements`
+
 .. _release/migration/3.3.0:
 
 Migrate to 3.3.0

--- a/doc/release/release_notes.rst
+++ b/doc/release/release_notes.rst
@@ -4,6 +4,41 @@
 Release Notes
 *************
 
+.. release:: Upcoming
+
+    .. change:: changed
+
+        Updated :mod:`wiz.graph` to make the following functions private:
+
+        * :func:`wiz.graph._compute_distance_mapping`
+        * :func:`wiz.graph._generate_variant_permutations`
+        * :func:`wiz.graph._compute_conflicting_matrix`
+        * :func:`wiz.graph._combined_requirements`
+        * :func:`wiz.graph._extract_conflicting_requirements`
+
+    .. change:: changed
+
+        Updated :func:`wiz.graph._generate_variant_permutations` to discard
+        permutations containing variant nodes with conflicting requirements.
+        Previously, the resolver had to consider all conflicting permutations
+        before attempting to :meth:`discover
+        <wiz.graph.Resolver.discover_combinations>` new combinations by
+        :meth:`downgrading <wiz.graph.Graph.downgrade_versions>` the versions
+        of conflicting nodes. As a results, precious time was wasted on
+        iterations which have little chance to lead to a solution when
+        downgrading versions of conflicting nodes is the most efficient way to
+        resolve a graph.
+
+    .. change:: changed
+
+        Updated :meth:`wiz.graph.Graph.relink_parents` to record error as
+        :exc:`~wiz.exception.GraphConflictsError` exception which can be raised
+        during the :meth:`validation <wiz.graph.Combination.validate>` of a
+        combination. This allows the resolver to :meth:`discover
+        <wiz.graph.Resolver.discover_combinations>` new combinations by
+        :meth:`downgrading <wiz.graph.Graph.downgrade_versions>` the versions
+        of the conflicting nodes involved if necessary.
+
 .. release:: 3.4.0
     :date: 2020-10-23
 

--- a/doc/release/release_notes.rst
+++ b/doc/release/release_notes.rst
@@ -24,14 +24,11 @@ Release Notes
         before attempting to :meth:`discover
         <wiz.graph.Resolver.discover_combinations>` new combinations by
         :meth:`downgrading <wiz.graph.Graph.downgrade_versions>` the versions
-        of conflicting nodes. As a results, precious time was wasted on
-        iterations which have little chance to lead to a solution when
-        downgrading versions of conflicting nodes is the most efficient way to
-        resolve a graph.
+        of conflicting nodes.
 
     .. change:: changed
 
-        Updated :meth:`wiz.graph.Graph.relink_parents` to record error as
+        Updated :meth:`wiz.graph.Graph.relink_parents` to record errors as
         :exc:`~wiz.exception.GraphConflictsError` exception which can be raised
         during the :meth:`validation <wiz.graph.Combination.validate>` of a
         combination. This allows the resolver to :meth:`discover

--- a/source/wiz/exception.py
+++ b/source/wiz/exception.py
@@ -134,11 +134,11 @@ class GraphConflictsError(GraphResolutionError):
         :param conflicting: Mapping of conflicting node identifiers per
             requirement. It should be in the form of::
 
-            {
-                Requirement("foo >=0.1.0, <1"): {"bar", "bim"},
-                Requirement("foo >2"): {"baz},
-                ...
-            }
+                {
+                    Requirement("foo >=0.1.0, <1"): {"bar", "bim"},
+                    Requirement("foo >2"): {"baz},
+                    ...
+                }
 
         """
         # Sort conflicting requirements per ascending number of conflicting

--- a/source/wiz/exception.py
+++ b/source/wiz/exception.py
@@ -19,6 +19,12 @@ class WizError(Exception):
         """Return human readable representation."""
         return str(self.message)
 
+    def __eq__(self, other):
+        """Compare with *other*."""
+        if isinstance(other, WizError):
+            return self.message == other.message
+        return False
+
 
 class CurrentSystemError(WizError):
     """Raise when the system is incorrect."""
@@ -165,6 +171,12 @@ class GraphConflictsError(GraphResolutionError):
             )
         )
 
+    def __eq__(self, other):
+        """Compare with *other*."""
+        if isinstance(other, GraphConflictsError):
+            return self.conflicts == other.conflicts
+        return super(GraphConflictsError, self).__eq__(other)
+
 
 class GraphInvalidNodesError(GraphResolutionError):
     """Raise when invalid nodes are found in the graph."""
@@ -191,6 +203,12 @@ class GraphInvalidNodesError(GraphResolutionError):
                 )
             )
         )
+
+    def __eq__(self, other):
+        """Compare with *other*."""
+        if isinstance(other, GraphInvalidNodesError):
+            return self.error_mapping == other.error_mapping
+        return super(GraphInvalidNodesError, self).__eq__(other)
 
 
 class GraphVariantsError(GraphResolutionError):

--- a/source/wiz/graph.py
+++ b/source/wiz/graph.py
@@ -487,6 +487,10 @@ def _extract_optimized_variant_groups(variant_groups, conflicting):
     :return: List of optimized variant groups.
 
     """
+    # Nothing to optimize if there is less than 2 definition groups.
+    if len(variant_groups) < 2:
+        return [variant_groups]
+
     variant_groups_list = []
 
     # Compute optimized variants group for each variant group within each
@@ -554,9 +558,9 @@ def _filtered_variant_groups(variant_groups, callback):
         ...     (("B[V2]",), ("B[V1]",))
         ... )
         >>> _filtered_variant_groups(
-        ...     groups, callback _, _id= _id not in ("A[V1]=2", "B[V1]")
+        ...     groups, callback=lambda _, _id: _id not in ("A[V1]=2", "B[V1]")
         ... )
-        ((("A[V1]=1", ("A[V2]",)), (("B[V2]",),))
+        ((("A[V1]=1",), ("A[V2]",)), (("B[V2]",),))
 
     :param variant_groups: :func:`Sorted <_sorted_variant_groups>` variant
         groups tuple. It should be in the form of::

--- a/source/wiz/graph.py
+++ b/source/wiz/graph.py
@@ -655,7 +655,7 @@ def _compute_conflicting_matrix(graph, variant_groups):
     return mapping
 
 
-def combined_requirements(graph, nodes):
+def _combined_requirements(graph, nodes):
     """Return combined requirements from *nodes* in *graph*.
 
     :param graph: Instance of :class:`Graph`.
@@ -693,7 +693,7 @@ def combined_requirements(graph, nodes):
     return requirement
 
 
-def extract_conflicting_requirements(graph, nodes):
+def _extract_conflicting_requirements(graph, nodes):
     """Return mapping of conflicting node identifiers per requirement.
 
     A requirement is conflicting when it is not overlapping with at least one
@@ -1458,7 +1458,7 @@ class Graph(object):
             if not len(_nodes):
                 definition_id = node_removed.definition.qualified_identifier
                 nodes = self.nodes(definition_identifier=definition_id)
-                conflicts = extract_conflicting_requirements(
+                conflicts = _extract_conflicting_requirements(
                     self, nodes + [node_removed]
                 )
 
@@ -1566,7 +1566,7 @@ class Graph(object):
 
             # Extract combined requirement to node and modify it to exclude
             # current package version.
-            requirement = combined_requirements(self, [node])
+            requirement = _combined_requirements(self, [node])
             exclusion_requirement = wiz.utility.get_requirement(
                 "{} != {}".format(requirement.name, node.package.version)
             )
@@ -2000,7 +2000,7 @@ class Combination(object):
                 continue
 
             # Compute combined requirements from all conflicting nodes.
-            requirement = combined_requirements(self._graph, nodes)
+            requirement = _combined_requirements(self._graph, nodes)
 
             # Query common packages from this combined requirements.
             packages = self._discover_packages(
@@ -2135,7 +2135,7 @@ class Combination(object):
             )
 
         except wiz.exception.RequestNotFound:
-            conflicting = extract_conflicting_requirements(self._graph, nodes)
+            conflicting = _extract_conflicting_requirements(self._graph, nodes)
             parents = set(itertools.chain(*conflicting.values()))
 
             # Push conflict at the end of the queue if it has conflicting

--- a/source/wiz/graph.py
+++ b/source/wiz/graph.py
@@ -208,8 +208,9 @@ class Resolver(object):
         self._conflicting_variants.update(identifiers)
 
         self._logger.debug(
-            "Combination will be extracted for following variant groups: {!r}"
-            .format(groups)
+            "Conflicting variant groups:\n{}\n".format(
+                "\n".join([" * {!r}".format(g) for g in groups])
+            )
         )
 
         wiz.history.record_action(
@@ -225,10 +226,18 @@ class Resolver(object):
                 if index + 1 > self._maximum_combinations:
                     return
 
-                yield Combination(
-                    graph, nodes_to_remove=identifiers.difference(
-                        {_id for _group in permutation for _id in _group}
+                # Flatten permutation groups.
+                permutation = {_id for _group in permutation for _id in _group}
+
+                self._logger.debug(
+                    "Generate combination with only following variants:\n"
+                    "{}\n".format(
+                        "\n".join([" * {}".format(_id) for _id in permutation])
                     )
+                )
+
+                yield Combination(
+                    graph, nodes_to_remove=identifiers.difference(permutation)
                 )
 
         self._iterator = itertools.chain(

--- a/source/wiz/graph.py
+++ b/source/wiz/graph.py
@@ -567,14 +567,10 @@ def extract_conflicting_requirements(graph, nodes):
             {
                 "requirement": Requirement("foo >=0.1.0, <1"),
                 "identifiers": {"bar", "bim"},
-                "conflicts": {"baz"},
-                "graph": Graph()
             },
             {
                 "requirement": Requirement("foo >2"),
                 "identifiers": {"baz"},
-                "conflicts": {"bar", "bim"},
-                "graph": Graph()
             }
         ]
 
@@ -637,12 +633,8 @@ def extract_conflicting_requirements(graph, nodes):
         mapping2.items(), key=lambda v: (len(v[1]), str(v[0])), reverse=True
     ):
         conflicts.append({
-            "graph": graph,
             "requirement": requirement,
             "identifiers": mapping1[requirement],
-            "conflicts": set(itertools.chain(
-                *[mapping1[r] for r in conflicting_requirements]
-            ))
         })
 
     return conflicts

--- a/source/wiz/graph.py
+++ b/source/wiz/graph.py
@@ -295,11 +295,11 @@ def compute_distance_mapping(graph):
     """Return distance mapping for each node of *graph*.
 
     The mapping indicates the shortest possible distance of each node
-    identifier from the :attr:`root <Graph.ROOT>` level of the *graph* with
+    identifier from the :attr:`root <Graph.ROOT>` level of the graph with
     corresponding parent node identifier.
 
     The distance is defined by the sum of the weights from each node to the
-    :attr:`root <Graph.ROOT>` level of the *graph*.
+    :attr:`root <Graph.ROOT>` level of the graph.
 
     This is using `Dijkstra's shortest path algorithm
     <https://en.wikipedia.org/wiki/Dijkstra%27s_algorithm>`_.
@@ -367,7 +367,11 @@ def compute_distance_mapping(graph):
 
 
 def generate_variant_permutations(graph, variant_groups):
-    """Yield all possible permutations of the variant groups.
+    """Yield valid permutations of the variant groups.
+
+    Group containing nodes nearest to the :attr:`root <Graph.ROOT>` level of the
+    graph are yield first and variant permutations containing conflicting
+    requirements are discarded.
 
     :param graph: Instance of :class:`Graph`.
 
@@ -450,16 +454,6 @@ def generate_variant_permutations(graph, variant_groups):
 
             permutations_used.add(_hash)
             yield permutation
-
-    # Once all optimized permutations are exhausted, test all other
-    # permutations.
-
-    for permutation in itertools.product(*groups):
-        _hash = hash(tuple(sorted(permutation)))
-        if _hash in permutations_used:
-            continue
-
-        yield permutation
 
 
 def compute_conflicting_matrix(graph, variant_groups):

--- a/source/wiz/graph.py
+++ b/source/wiz/graph.py
@@ -2388,13 +2388,12 @@ class _DistanceQueue(dict):
     """Distance mapping which can be used as a queue.
 
     Distances are cumulated weights computed between each node and the
-    :attr:`root of the graph <Graph.ROOT>`.
+    :attr:`root <Graph.ROOT>` level of the graph. Keys of the dictionary are
+    node identifiers added into a queue, and values are their respective
+    distances.
 
-    Keys of the dictionary are node identifiers added into a queue, and
-    values are their respective distances.
-
-    The advantage over a standard heapq-based distance queue is that distances
-    of node identifiers can be efficiently updated (amortized O(1)).
+    The advantage over a standard :mod:`heapq`-based distance queue is that
+    distances of node identifiers can be efficiently updated (amortized O(1)).
 
     .. note::
 

--- a/source/wiz/graph.py
+++ b/source/wiz/graph.py
@@ -411,9 +411,8 @@ def generate_variant_permutations(graph, variant_groups):
     # If all variant groups are conflicting, simply return one permutation of
     # the original variant groups.
     if len(variant_groups_list) == 0:
-        for permutation in itertools.product(*variant_groups):
-            yield permutation
-            return
+        yield tuple(tuple(def_grp[0]) for def_grp in variant_groups)
+        return
 
     # Otherwise return permutations for each optimized variant groups.
     for _variant_groups in variant_groups_list:

--- a/source/wiz/graph.py
+++ b/source/wiz/graph.py
@@ -220,7 +220,7 @@ class Resolver(object):
         def _generate_combinations():
             """Yield combinations from variant groups."""
             for index, permutation in enumerate(
-                generate_variant_permutations(graph, groups)
+                _generate_variant_permutations(graph, groups)
             ):
                 if index + 1 > self._maximum_combinations:
                     return
@@ -291,7 +291,7 @@ class Resolver(object):
             return True
 
 
-def compute_distance_mapping(graph):
+def _compute_distance_mapping(graph):
     """Return distance mapping for each node of *graph*.
 
     The mapping indicates the shortest possible distance of each node
@@ -366,7 +366,7 @@ def compute_distance_mapping(graph):
     return distance_mapping
 
 
-def generate_variant_permutations(graph, variant_groups):
+def _generate_variant_permutations(graph, variant_groups):
     """Yield valid permutations of the variant groups.
 
     Group containing nodes nearest to the :attr:`root <Graph.ROOT>` level of the
@@ -389,7 +389,7 @@ def generate_variant_permutations(graph, variant_groups):
         does not exist in the graph.
 
     """
-    distance_mapping = compute_distance_mapping(graph)
+    distance_mapping = _compute_distance_mapping(graph)
 
     # Record permutations previously used.
     permutations_used = set()
@@ -2379,7 +2379,7 @@ class Combination(object):
 
         """
         if self._distance_mapping is None or force_update:
-            self._distance_mapping = compute_distance_mapping(self._graph)
+            self._distance_mapping = _compute_distance_mapping(self._graph)
 
         return self._distance_mapping
 

--- a/source/wiz/utility.py
+++ b/source/wiz/utility.py
@@ -90,6 +90,9 @@ def is_overlapping(requirement1, requirement2):
         >>> is_overlapping(Requirement("foo >= 10"), Requirement("foo < 8"))
         False
 
+        >>> is_overlapping(Requirement("foo[V2]"), Requirement("foo[V1]"))
+        False
+
     :param requirement1: Instance of
         :class:`packaging.requirements.Requirement`.
 
@@ -98,15 +101,17 @@ def is_overlapping(requirement1, requirement2):
 
     :return: Boolean value.
 
-    :raise: :exc:`wiz.exception.GraphResolutionError` if requirements cannot
-        be compared.
+    :raise: :exc:`ValueError` if requirements cannot be compared.
 
     """
     if requirement1.name != requirement2.name:
-        raise wiz.exception.GraphResolutionError(
+        raise ValueError(
             "Impossible to compare requirements with different names "
             "['{}' and '{}'].".format(requirement1.name, requirement2.name)
         )
+
+    if requirement1.extras != requirement2.extras:
+        return False
 
     r1 = extract_version_ranges(requirement1)
     r2 = extract_version_ranges(requirement2)

--- a/test/integration/test_resolver.py
+++ b/test/integration/test_resolver.py
@@ -242,8 +242,8 @@ def test_scenario_2():
     assert (
         "The dependency graph could not be resolved due to the "
         "following requirement conflicts:\n"
-        "  * ::D >0.1.0 \t[B==0.1.0]\n"
-        "  * ::D ==0.1.0 \t[C==0.3.2]"
+        "  * ::D ==0.1.0 \t[C==0.3.2]\n"
+        "  * ::D >0.1.0 \t[B==0.1.0]"
     ) in str(error.value)
 
 
@@ -2455,8 +2455,8 @@ def test_scenario_32():
     assert (
         "The dependency graph could not be resolved due to the "
         "following requirement conflicts:\n"
-        "  * ::B >1 \t[root]\n"
-        "  * ::B <1 \t[C==0.1.0]"
+        "  * ::B <1 \t[C==0.1.0]\n"
+        "  * ::B >1 \t[root]"
     ) in str(error.value)
 
 
@@ -2598,7 +2598,7 @@ def test_scenario_34():
          |
          `--(A[V2]): A[V2]==1.0.0
              |
-             `--(B >=1, <2): B==1.0.0
+             `--(B >=2, <3): B==2.0.0
 
     Expected: Unable to compute due to requirement compatibility between
     'A[V2]' and 'A[V3]'.
@@ -2646,9 +2646,9 @@ def test_scenario_34():
 
     assert (
         "The dependency graph could not be resolved due to the following "
-        "error(s):\n"
-        "  * root: Requirement '::A[V3]' can not be satisfied once "
-        "'A[V3]==1.0.0' is removed from the graph."
+        "requirement conflicts:\n"
+        "  * ::A[V2] \t[C]\n"
+        "  * ::A[V3] \t[root]"
     ) in str(error.value)
 
 
@@ -2745,11 +2745,10 @@ def test_scenario_35():
 
     assert (
         "The dependency graph could not be resolved due to the following "
-        "error(s):\n"
-        "  * C: Requirement '::A[V2]' can not be satisfied once 'A[V2]==1.0.0' "
-        "is removed from the graph.\n"
-        "  * D==0.1.0: Requirement '::A[V3]' can not be satisfied once "
-        "'A[V3]==1.0.0' is removed from the graph."
+        "requirement conflicts:\n"
+        "  * ::A \t[root]\n"
+        "  * ::A[V2] \t[C]\n"
+        "  * ::A[V3] \t[D==0.1.0]"
     ) in str(error.value)
 
 
@@ -2865,8 +2864,8 @@ def test_scenario_37():
     assert (
         "The dependency graph could not be resolved due to the following "
         "requirement conflicts:\n"
-        "  * ::A ==1.4.* \t[B==0.1.0]\n"
-        "  * ::A ==1.2.* \t[root]"
+        "  * ::A ==1.2.* \t[root]\n"
+        "  * ::A ==1.4.* \t[B==0.1.0]"
     ) in str(error.value)
 
 
@@ -2924,8 +2923,8 @@ def test_scenario_38():
     assert (
         "The dependency graph could not be resolved due to the following "
         "requirement conflicts:\n"
-        "  * ::A ==1.4.* \t[B==0.1.0]\n"
-        "  * ::A ==1.2.* \t[root]"
+        "  * ::A ==1.2.* \t[root]\n"
+        "  * ::A ==1.4.* \t[B==0.1.0]"
     ) in str(error.value)
 
 
@@ -3047,3 +3046,163 @@ def test_scenario_39():
     assert len(packages) == 2
     assert packages[0].identifier == "B==1"
     assert packages[1].identifier == "A[V1]"
+
+
+def test_scenario_40():
+    """Compute packages for the following graph.
+
+    Like scenario 34, a conflict appear when relinking parents as two
+    requirements are explicitly requesting conflicting variants: "A[V2]" and
+    "A[V3]". But this time, the graph contains a version conflict which will
+    be resolved by removing "A[V2]", hence making this conflict irrelevant.
+
+    Root
+     |
+     |--(A[V3]): A[V3]==1.0.0
+     |   |
+     |   `--(B >=3, <4): B==3.0.0
+     |
+     |--(C >=1): C==2.0.0
+     |   |
+     |   `--(A[V2]): A[V2]==1.0.0
+     |       |
+     |       `--(B >=2, <3): B==2.0.0
+     |
+     `--(E): E
+         |
+         `--(C >=1, <2): C==1.5.0
+
+    Expected: E, C==1.5.0, B==3.0.0, A[V3]==1.0.0
+
+    """
+    definition_mapping = {
+        "A": {
+            "1.0.0": wiz.definition.Definition({
+                "identifier": "A",
+                "version": "1.0.0",
+                "variants": [
+                    {
+                        "identifier": "V3",
+                        "requirements": ["B >=3, <4"]
+                    },
+                    {
+                        "identifier": "V2",
+                        "requirements": ["B >=2, <3"]
+                    }
+                ]
+            })
+        },
+        "B": {
+            "3.0.0": wiz.definition.Definition({
+                "identifier": "B",
+                "version": "3.0.0"
+            }),
+            "2.0.0": wiz.definition.Definition({
+                "identifier": "B",
+                "version": "2.0.0"
+            }),
+        },
+        "C": {
+            "2.0.0": wiz.definition.Definition({
+                "identifier": "C",
+                "version": "2.0.0",
+                "requirements": ["A[V2]"]
+            }),
+            "1.5.0": wiz.definition.Definition({
+                "identifier": "C",
+                "version": "1.5.0"
+            }),
+        },
+        "E": {
+            "-": wiz.definition.Definition({
+                "identifier": "E",
+                "requirements": ["C >=1, <2"]
+            }),
+        }
+    }
+
+    resolver = wiz.graph.Resolver(definition_mapping)
+    packages = resolver.compute_packages([
+        Requirement("A[V3]"), Requirement("C >=1"), Requirement("E"),
+    ])
+
+    assert len(packages) == 4
+    assert packages[0].identifier == "E"
+    assert packages[1].identifier == "C==1.5.0"
+    assert packages[2].identifier == "B==3.0.0"
+    assert packages[3].identifier == "A[V3]==1.0.0"
+
+
+def test_scenario_41():
+    """Compute packages for the following graph.
+
+    Like scenario 34, a conflict appear when relinking parents as two
+    requirements are explicitly requesting conflicting variants: "A[V2]" and
+    "A[V3]". But this time, the resolver can downgrade versions of conflicting
+    nodes to find a solution.
+
+    Root
+     |
+     |--(A[V3]): A[V3]==1.0.0
+     |   |
+     |   `--(B >=3, <4): B==3.0.0
+     |
+     `--(C): C==1.0.0
+         |
+         `--(A[V2]): A[V2]==1.0.0
+             |
+             `--(B >=2, <3): B==2.0.0
+
+    Expected: C==0.5.0, B==3.0.0, A[V3]==1.0.0
+
+    """
+    definition_mapping = {
+        "A": {
+            "1.0.0": wiz.definition.Definition({
+                "identifier": "A",
+                "version": "1.0.0",
+                "variants": [
+                    {
+                        "identifier": "V3",
+                        "requirements": ["B >=3, <4"]
+                    },
+                    {
+                        "identifier": "V2",
+                        "requirements": ["B >=2, <3"]
+                    }
+                ]
+            })
+        },
+        "B": {
+            "3.0.0": wiz.definition.Definition({
+                "identifier": "B",
+                "version": "3.0.0"
+            }),
+            "2.0.0": wiz.definition.Definition({
+                "identifier": "B",
+                "version": "2.0.0"
+            }),
+        },
+        "C": {
+            "1.0.0": wiz.definition.Definition({
+                "identifier": "C",
+                "version": "1.0.0",
+                "requirements": ["A[V2]"]
+            }),
+            "0.5.0": wiz.definition.Definition({
+                "identifier": "C",
+                "version": "0.5.0",
+            })
+        }
+    }
+
+    resolver = wiz.graph.Resolver(definition_mapping)
+
+    packages = resolver.compute_packages([
+        Requirement("A[V3]"), Requirement("C")
+    ])
+
+    assert len(packages) == 3
+    assert packages[0].identifier == "C==0.5.0"
+    assert packages[1].identifier == "B==3.0.0"
+    assert packages[2].identifier == "A[V3]==1.0.0"

--- a/test/unit/test_graph.py
+++ b/test/unit/test_graph.py
@@ -49,14 +49,14 @@ def mocked_combined_requirements(mocker):
 
 @pytest.fixture()
 def mocked_compute_distance_mapping(mocker):
-    """Return mocked wiz.graph.compute_distance_mapping function."""
-    return mocker.patch.object(wiz.graph, "compute_distance_mapping")
+    """Return mocked wiz.graph._compute_distance_mapping function."""
+    return mocker.patch.object(wiz.graph, "_compute_distance_mapping")
 
 
 @pytest.fixture()
 def mocked_generate_variant_permutations(mocker):
-    """Return mocked wiz.graph.generate_variant_permutations function."""
-    return mocker.patch.object(wiz.graph, "generate_variant_permutations")
+    """Return mocked wiz.graph._generate_variant_permutations function."""
+    return mocker.patch.object(wiz.graph, "_generate_variant_permutations")
 
 
 @pytest.fixture()
@@ -1051,7 +1051,7 @@ def test_resolver_discover_combinations_fail(
 def test_compute_distance_mapping_empty(mocked_graph):
     """Compute distance mapping from empty graph."""
     mocked_graph.outcoming.return_value = []
-    assert wiz.graph.compute_distance_mapping(mocked_graph) == {
+    assert wiz.graph._compute_distance_mapping(mocked_graph) == {
         "root": {"distance": 0, "parent": "root"}
     }
 
@@ -1069,7 +1069,7 @@ def test_compute_distance_mapping_one_node(mocker, mocked_graph):
     mocked_graph.outcoming = lambda _id: weights.get(_id, {}).keys()
     mocked_graph.link_weight = lambda _id1, _id2: weights[_id2][_id1]
 
-    assert wiz.graph.compute_distance_mapping(mocked_graph) == {
+    assert wiz.graph._compute_distance_mapping(mocked_graph) == {
         "root": {"distance": 0, "parent": "root"},
         "A": {"distance": 1, "parent": "root"}
     }
@@ -1088,7 +1088,7 @@ def test_compute_distance_mapping_two_nodes(mocker, mocked_graph):
     mocked_graph.outcoming = lambda _id: weights.get(_id, {}).keys()
     mocked_graph.link_weight = lambda _id1, _id2: weights[_id2][_id1]
 
-    assert wiz.graph.compute_distance_mapping(mocked_graph) == {
+    assert wiz.graph._compute_distance_mapping(mocked_graph) == {
         "root": {"distance": 0, "parent": "root"},
         "A": {"distance": 1, "parent": "root"},
         "B": {"distance": 2, "parent": "root"}
@@ -1108,7 +1108,7 @@ def test_compute_distance_mapping_three_nodes(mocker, mocked_graph):
     mocked_graph.outcoming = lambda _id: weights.get(_id, {}).keys()
     mocked_graph.link_weight = lambda _id1, _id2: weights[_id2][_id1]
 
-    assert wiz.graph.compute_distance_mapping(mocked_graph) == {
+    assert wiz.graph._compute_distance_mapping(mocked_graph) == {
         "root": {"distance": 0, "parent": "root"},
         "A": {"distance": 1, "parent": "root"},
         "B": {"distance": 2, "parent": "root"},
@@ -1129,7 +1129,7 @@ def test_compute_distance_mapping_two_levels(mocker, mocked_graph):
     mocked_graph.outcoming = lambda _id: weights.get(_id, {}).keys()
     mocked_graph.link_weight = lambda _id1, _id2: weights[_id2][_id1]
 
-    assert wiz.graph.compute_distance_mapping(mocked_graph) == {
+    assert wiz.graph._compute_distance_mapping(mocked_graph) == {
         "root": {"distance": 0, "parent": "root"},
         "A": {"distance": 1, "parent": "root"},
         "B": {"distance": 2, "parent": "A"}
@@ -1149,7 +1149,7 @@ def test_compute_distance_mapping_three_levels(mocker, mocked_graph):
     mocked_graph.outcoming = lambda _id: weights.get(_id, {}).keys()
     mocked_graph.link_weight = lambda _id1, _id2: weights[_id2][_id1]
 
-    assert wiz.graph.compute_distance_mapping(mocked_graph) == {
+    assert wiz.graph._compute_distance_mapping(mocked_graph) == {
         "root": {"distance": 0, "parent": "root"},
         "A": {"distance": 1, "parent": "root"},
         "B": {"distance": 2, "parent": "A"},
@@ -1170,7 +1170,7 @@ def test_compute_distance_mapping_circular_dependency(mocker, mocked_graph):
     mocked_graph.outcoming = lambda _id: weights.get(_id, {}).keys()
     mocked_graph.link_weight = lambda _id1, _id2: weights[_id2][_id1]
 
-    assert wiz.graph.compute_distance_mapping(mocked_graph) == {
+    assert wiz.graph._compute_distance_mapping(mocked_graph) == {
         "root": {"distance": 0, "parent": "root"},
         "A": {"distance": 1, "parent": "root"},
         "B": {"distance": 2, "parent": "root"}
@@ -1195,7 +1195,7 @@ def test_compute_distance_mapping_multi_levels(mocker, mocked_graph):
     mocked_graph.outcoming = lambda _id: weights.get(_id, {}).keys()
     mocked_graph.link_weight = lambda _id1, _id2: weights[_id2][_id1]
 
-    assert wiz.graph.compute_distance_mapping(mocked_graph) == {
+    assert wiz.graph._compute_distance_mapping(mocked_graph) == {
         "root": {"distance": 0, "parent": "root"},
         "A": {"distance": 1, "parent": "root"},
         "B": {"distance": 2, "parent": "root"},
@@ -1224,7 +1224,7 @@ def test_compute_distance_mapping_unreachable_nodes(mocker, mocked_graph):
     mocked_graph.outcoming = lambda _id: weights.get(_id, {}).keys()
     mocked_graph.link_weight = lambda _id1, _id2: weights[_id2][_id1]
 
-    assert wiz.graph.compute_distance_mapping(mocked_graph) == {
+    assert wiz.graph._compute_distance_mapping(mocked_graph) == {
         "root": {"distance": 0, "parent": "root"},
         "A": {"distance": 1, "parent": "root"},
         "B": {"distance": None, "parent": None},
@@ -1256,7 +1256,7 @@ def test_compute_distance_mapping_complex(mocker, mocked_graph):
     mocked_graph.outcoming = lambda _id: weights.get(_id, {}).keys()
     mocked_graph.link_weight = lambda _id1, _id2: weights[_id2][_id1]
 
-    assert wiz.graph.compute_distance_mapping(mocked_graph) == {
+    assert wiz.graph._compute_distance_mapping(mocked_graph) == {
         "root": {"distance": 0, "parent": "root"},
         "A": {"distance": 1, "parent": "root"},
         "B": {"distance": 2, "parent": "root"},
@@ -1295,7 +1295,7 @@ def test_generate_variant_permutations_none_conflicting(
         "B[V1]==1": {"A[V3]": False, "A[V2]": False, "A[V1]": False},
     }
 
-    result = wiz.graph.generate_variant_permutations(
+    result = wiz.graph._generate_variant_permutations(
         mocked_graph, variant_groups
     )
 
@@ -1341,7 +1341,7 @@ def test_generate_variant_permutations_all_conflicting(
         "B[V1]==1": {"A[V3]": True, "A[V2]": True, "A[V1]": True},
     }
 
-    result = wiz.graph.generate_variant_permutations(
+    result = wiz.graph._generate_variant_permutations(
         mocked_graph, variant_groups
     )
 
@@ -1381,7 +1381,7 @@ def test_generate_variant_permutations_optimized_two_groups(
         "B[V1]==1": {"A[V3]": True, "A[V2]": True, "A[V1]": False},
     }
 
-    result = wiz.graph.generate_variant_permutations(
+    result = wiz.graph._generate_variant_permutations(
         mocked_graph, variant_groups
     )
 
@@ -1453,7 +1453,7 @@ def test_generate_variant_permutations_optimized_three_groups(
         }
     }
 
-    result = wiz.graph.generate_variant_permutations(
+    result = wiz.graph._generate_variant_permutations(
         mocked_graph, variant_groups
     )
 

--- a/test/unit/test_graph.py
+++ b/test/unit/test_graph.py
@@ -61,8 +61,8 @@ def mocked_generate_variant_permutations(mocker):
 
 @pytest.fixture()
 def mocked_compute_conflicting_matrix(mocker):
-    """Return mocked wiz.graph.compute_conflicting_matrix function."""
-    return mocker.patch.object(wiz.graph, "compute_conflicting_matrix")
+    """Return mocked wiz.graph._compute_conflicting_matrix function."""
+    return mocker.patch.object(wiz.graph, "_compute_conflicting_matrix")
 
 
 @pytest.fixture()
@@ -1389,8 +1389,8 @@ def test_generate_variant_permutations_optimized(
     assert list(result) == [
         (("B[V1]==1",), ("A[V1]",)),
         (("B[V2]==2", "B[V2]==1"), ("A[V3]",)),
-        (("B[V2]==1",), ("A[V2]",)),
         (("B[V2]==2", "B[V2]==1"), ("A[V1]",)),
+        (("B[V2]==1",), ("A[V2]",)),
     ]
 
     mocked_compute_conflicting_matrix.assert_called_once_with(
@@ -1399,24 +1399,24 @@ def test_generate_variant_permutations_optimized(
 
 
 @pytest.mark.parametrize("variant_groups, expected", [
-    (set(), []),
+    (set(), ()),
     (
         {(("B[V2]==2", "B[V2]==1"), ("B[V1]==1",))},
-        [(("B[V1]==1",), ("B[V2]==2", "B[V2]==1"))]
+        ((("B[V1]==1",), ("B[V2]==2", "B[V2]==1")),)
     ),
     (
         {(("B[V1]==1",), ("B[V2]==2", "B[V2]==1"))},
-        [(("B[V1]==1",), ("B[V2]==2", "B[V2]==1"))]
+        ((("B[V1]==1",), ("B[V2]==2", "B[V2]==1")),)
     ),
     (
         {
             (("A[V3]",), ("A[V2]",), ("A[V1]",)),
             (("B[V2]==2", "B[V2]==1"), ("B[V1]==1",))
         },
-        [
+        (
             (("B[V1]==1",), ("B[V2]==2", "B[V2]==1")),
             (("A[V3]",), ("A[V2]",), ("A[V1]",)),
-        ]
+        )
     )
 ], ids=[
     "empty",
@@ -1435,14 +1435,14 @@ def test_sorted_variant_groups(variant_groups, expected):
         "B[V1]==1": {"distance": 1},
     }
 
-    assert wiz.graph.sorted_variant_groups(variant_groups, mapping) == expected
+    assert wiz.graph._sorted_variant_groups(variant_groups, mapping) == expected
 
 
 def test_compute_conflicting_matrix_empty(
     mocked_graph, mocked_check_conflicting_requirements
 ):
     """Compute conflicting matrix for empty variant group."""
-    assert wiz.graph.compute_conflicting_matrix(mocked_graph, set()) == {}
+    assert wiz.graph._compute_conflicting_matrix(mocked_graph, set()) == {}
 
     mocked_check_conflicting_requirements.assert_not_called()
 
@@ -1452,7 +1452,7 @@ def test_compute_conflicting_matrix_one_group(
 ):
     """Compute conflicting matrix for one variant group."""
     groups = {(("A[V3]",), ("A[V2]",))}
-    assert wiz.graph.compute_conflicting_matrix(mocked_graph, groups) == {}
+    assert wiz.graph._compute_conflicting_matrix(mocked_graph, groups) == {}
 
     mocked_check_conflicting_requirements.assert_not_called()
 
@@ -1514,7 +1514,7 @@ def test_compute_conflicting_matrix_two_groups(
     mocked_graph.node = _fetch_mocked_node
     mocked_check_conflicting_requirements.side_effect = conflicts
 
-    result = wiz.graph.compute_conflicting_matrix(mocked_graph, groups)
+    result = wiz.graph._compute_conflicting_matrix(mocked_graph, groups)
     assert result == expected
 
     assert mocked_check_conflicting_requirements.call_args_list == [
@@ -1645,7 +1645,7 @@ def test_compute_conflicting_matrix_three_groups(
     mocked_graph.node = _fetch_mocked_node
     mocked_check_conflicting_requirements.side_effect = conflicts
 
-    result = wiz.graph.compute_conflicting_matrix(mocked_graph, groups)
+    result = wiz.graph._compute_conflicting_matrix(mocked_graph, groups)
     assert result == expected
 
     assert mocked_check_conflicting_requirements.call_args_list == [

--- a/test/unit/test_graph.py
+++ b/test/unit/test_graph.py
@@ -1705,22 +1705,16 @@ def test_extract_conflicting_requirements(mocked_graph):
 
     assert conflicts == [
         {
-            "graph": mocked_graph,
             "requirement": Requirement("foo >=4, <5"),
             "identifiers": {"G", "H"},
-            "conflicts": {"F", "root"}
         },
         {
-            "graph": mocked_graph,
             "requirement": Requirement("foo ==3.0.0"),
             "identifiers": {"root"},
-            "conflicts": {"G", "H"}
         },
         {
-            "graph": mocked_graph,
             "requirement": Requirement("foo ==3.*"),
             "identifiers": {"F"},
-            "conflicts": {"G", "H"}
         }
     ]
 

--- a/test/unit/test_utility.py
+++ b/test/unit/test_utility.py
@@ -100,8 +100,8 @@ def test_is_overlapping(
     mocker, mocked_extract_version_ranges, ranges1, ranges2, expected
 ):
     """Indicates whether requirements are overlapping."""
-    req1 = mocker.Mock()
-    req2 = mocker.Mock()
+    req1 = mocker.Mock(extras=set())
+    req2 = mocker.Mock(extras=set())
 
     # Hack due to the impossibility to directly mock an attribute called "name"
     # See: https://bradmontgomery.net/blog/how-world-do-you-mock-name-attribute
@@ -112,17 +112,30 @@ def test_is_overlapping(
     assert wiz.utility.is_overlapping(req1, req2) == expected
 
 
+def test_is_overlapping_with_variants(mocker):
+    """Fail to compare requirement with different variant."""
+    req1 = mocker.Mock(extras={"V1"})
+    req2 = mocker.Mock(extras={"V2"})
+
+    # Hack due to the impossibility to directly mock an attribute called "name"
+    # See: https://bradmontgomery.net/blog/how-world-do-you-mock-name-attribute
+    type(req1).name = mocker.PropertyMock(return_value="foo")
+    type(req2).name = mocker.PropertyMock(return_value="foo")
+
+    assert wiz.utility.is_overlapping(req1, req2) is False
+
+
 def test_is_overlapping_fail(mocker):
     """Fail to compare requirement with different name."""
-    req1 = mocker.Mock()
-    req2 = mocker.Mock()
+    req1 = mocker.Mock(extras=set())
+    req2 = mocker.Mock(extras=set())
 
     # Hack due to the impossibility to directly mock an attribute called "name"
     # See: https://bradmontgomery.net/blog/how-world-do-you-mock-name-attribute
     type(req1).name = mocker.PropertyMock(return_value="foo")
     type(req2).name = mocker.PropertyMock(return_value="bar")
 
-    with pytest.raises(wiz.exception.GraphResolutionError) as error:
+    with pytest.raises(ValueError) as error:
         wiz.utility.is_overlapping(req1, req2)
 
     assert (


### PR DESCRIPTION
Optimize relinking and variant permutation logic

* Consider relinking issues as conflict errors to give the resolver a chance to downgrade versions for nodes involved and find a solution.
* Discard conflicting variants to give the resolver a chance to downgrade versions faster instead of wasting time on combinations which have a higher chance of failure.
* When all variants are conflicting, return one single permutation to record conflicts and jump to the version downgrade logic
